### PR TITLE
Add branches and commits endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,22 @@ request(app)
 
 ```ts
 // src/tools/myTool.ts (example)
-export function registerMyTool(app: express.Express) {
-  app.post('/tool/myTool', (req, res) => {
-    // tool logic …
-  });
-}
+  export function registerMyTool(app: express.Express) {
+    app.post('/tool/myTool', (req, res) => {
+      // tool logic …
+    });
+  }
 ```
+
+## GitLab Routes
+
+The server exposes a subset of GitLab REST API endpoints:
+
+- `GET /projects/:id/merge_requests`
+- `GET /projects/:id/merge_requests/:iid/discussions`
+- `GET /projects/:id/files/<path>?ref=<branch>`
+- `GET /projects/:id/branches`
+- `GET /projects/:id/commits`
 
 ---
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -20,6 +20,26 @@ export function createApp() {
     }
   });
 
+  // List branches of a project
+  app.get('/projects/:id/branches', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listBranches(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // List commits of a project
+  app.get('/projects/:id/commits', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listCommits(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // List discussions of a merge request
   app.get('/projects/:id/merge_requests/:iid/discussions', async (req, res, next: NextFunction) => {
     try {
@@ -33,7 +53,9 @@ export function createApp() {
   // Raw file content – RegExp route avoids path-to-regexp parsing issues
   app.get(/^\/projects\/(\d+)\/files\/(.+)$/, async (req, res, next: NextFunction) => {
     try {
-      const [projectId, filePath] = req.params as unknown as [string, string];
+      const params = req.params as unknown as { 0: string; 1: string };
+      const projectId = params[0];
+      const filePath = params[1];
       const ref = typeof req.query.ref === 'string' ? req.query.ref : 'main';
       const svc = new GitLabService();
       const content = await svc.getFile(projectId, filePath, ref);

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -10,6 +10,7 @@ export class GitLabService {
     this.client = axios.create({
       baseURL: this.baseUrl,
       headers: { 'PRIVATE-TOKEN': this.token },
+      proxy: false,
     });
   }
 
@@ -20,6 +21,16 @@ export class GitLabService {
 
   async listDiscussions(projectId: string | number, mrIid: string | number) {
     const { data } = await this.client.get(`/projects/${projectId}/merge_requests/${mrIid}/discussions`);
+    return data;
+  }
+
+  async listBranches(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/repository/branches`);
+    return data;
+  }
+
+  async listCommits(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/repository/commits`);
     return data;
   }
 

--- a/tests/gitlab.branches.test.ts
+++ b/tests/gitlab.branches.test.ts
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab branches endpoint', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('returns branch list from GitLab', async () => {
+    const mockData = [{ name: 'main' }];
+    nock(base)
+      .get('/api/v4/projects/123/repository/branches')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/branches');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});

--- a/tests/gitlab.commits.test.ts
+++ b/tests/gitlab.commits.test.ts
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab commits endpoint', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('returns commits list from GitLab', async () => {
+    const mockData = [{ id: 'abc123' }];
+    nock(base)
+      .get('/api/v4/projects/123/repository/commits')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/commits');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});


### PR DESCRIPTION
## Summary
- expose more GitLab API routes
- disable proxy in axios client
- document available GitLab routes
- test branches and commits endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a5a0181d4832b904d7e8ff962f47d