### PR TITLE
Add pipelines support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The server exposes the following endpoints:
 - `GET /projects/:id/files/<path>?ref=<branch>`
 - `GET /projects/:id/branches`
 - `GET /projects/:id/commits`
+- `GET /projects/:id/pipelines`
+- `GET /projects/:id/pipelines/:pipeline_id`
 - `GET /projects/:id/issues`
 - `POST /projects/:id/issues`
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -50,6 +50,26 @@ export function createApp() {
     }
   });
 
+  // List pipelines of a project
+  app.get('/projects/:id/pipelines', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listPipelines(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // Get a single pipeline
+  app.get('/projects/:id/pipelines/:pipelineId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.getPipeline(req.params.id, req.params.pipelineId));
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // List issues of a project
   app.get('/projects/:id/issues', async (req, res, next: NextFunction) => {
     try {

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -59,6 +59,18 @@ export class GitLabService {
     return data;
   }
 
+  async listPipelines(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/pipelines`);
+    return data;
+  }
+
+  async getPipeline(projectId: string | number, pipelineId: string | number) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/pipelines/${pipelineId}`,
+    );
+    return data;
+  }
+
   async listIssues(projectId: string | number): Promise<IssueResponse[]> {
     const { data } = await this.client.get(`/projects/${projectId}/issues`);
     return data;

--- a/tests/gitlab.pipelines.test.ts
+++ b/tests/gitlab.pipelines.test.ts
@@ -1,0 +1,37 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab pipelines endpoints', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('returns pipelines list from GitLab', async () => {
+    const mockData = [{ id: 1, status: 'success' }];
+    nock(base)
+      .get('/api/v4/projects/123/pipelines')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/pipelines');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns a pipeline', async () => {
+    const mockData = { id: 1, status: 'success' };
+    nock(base)
+      .get('/api/v4/projects/123/pipelines/1')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/pipelines/1');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for GitLab pipelines endpoints
- implement `listPipelines` and `getPipeline` in GitLabService
- expose new `/projects/:id/pipelines` routes
- document new API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a78e00288832b8c44be847e0b00dd