### PR TITLE
Add STDIO transport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ entry like the following:
 }
 ```
 
+### Running via STDIO
+
+You can run the server without any network transport using the STDIO mode.
+
+```bash
+npm run build
+npm run start:stdio
+```
+
+This starts an MCP server that communicates through standard input/output.
+
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "jest",
     "build": "tsc",
     "dev": "nodemon --exec ts-node src/server.ts",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "start:stdio": "node dist/stdioServer.js"
   },
   "keywords": [],
   "author": "",

--- a/src/stdioServer.ts
+++ b/src/stdioServer.ts
@@ -1,0 +1,38 @@
+import { McpServer } from '@modelcontextprotocol/sdk/dist/cjs/server/mcp';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/dist/cjs/server/stdio';
+import { z } from 'zod';
+
+const server = new McpServer({
+  name: 'mcp-server-extended-gitlab',
+  version: '1.0.0',
+});
+
+server.tool(
+  'hello',
+  'Greets the provided name',
+  { name: z.string().describe('Name to greet') },
+  async ({ name }) => ({
+    content: [
+      { type: 'text', text: `Hello, ${name}!` },
+    ],
+  }),
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  process.on('SIGINT', () => shutdown(transport));
+  process.on('SIGTERM', () => shutdown(transport));
+  await server.connect(transport);
+  console.error('STDIO server started');
+}
+
+async function shutdown(transport: StdioServerTransport) {
+  console.error('Shutting down...');
+  await transport.close();
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Failed to start STDIO server:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- implement new `stdioServer` entry using MCP SDK
- expose `start:stdio` npm script
- document STDIO usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a7a232ed4832baabe00f6d3da9e26