### PR TITLE
Migrate server to use mcp-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A small server exposing selected GitLab REST API endpoints as tools for the [Mod
 * **GitLab integration** for merge requests, branches, commits, discussions, issues and file content.
 * **TDD-first** workflow – Jest + ts-jest preconfigured.
 * **Hot reload** in development via `nodemon`.
-* Uses the MCP TypeScript SDK via a local path dependency.
+* Built on the mcp-framework for tools and transports.
 * **Server-Sent Events** transport for streaming MCP responses.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "file:../typescript-sdk",
+        "@modelcontextprotocol/sdk": "^1.11.0",
         "axios": "^1.9.0",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "file:../typescript-sdk",
+    "@modelcontextprotocol/sdk": "^1.11.0",
     "axios": "^1.9.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",

--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -2,12 +2,18 @@
 const pkg = require('../package.json');
 
 export async function createMcpServer({ port }: { port?: number } = {}) {
-  const { MCPServer } = await import('mcp-framework');
+  let MCPServer: any;
+  try {
+    ({ MCPServer } = require('mcp-framework'));
+  } catch {
+    const importer = new Function('p', 'return import(p)');
+    ({ MCPServer } = await importer('mcp-framework'));
+  }
   const envPort = Number(process.env.PORT);
   const server = new MCPServer({
     name: pkg.name,
     version: pkg.version,
-    basePath: './dist',
+    basePath: __dirname,
     transport: {
       type: 'sse',
       options: {

--- a/src/stdioServer.ts
+++ b/src/stdioServer.ts
@@ -1,38 +1,13 @@
-import { McpServer } from '@modelcontextprotocol/sdk/dist/cjs/server/mcp';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/dist/cjs/server/stdio';
-import { z } from 'zod';
+const importer = new Function('p', 'return import(p)');
+(async () => {
+  const { MCPServer } = await importer('mcp-framework');
+  const server = new MCPServer({
+    basePath: __dirname,
+    transport: { type: 'stdio' },
+  });
 
-const server = new McpServer({
-  name: 'mcp-server-extended-gitlab',
-  version: '1.0.0',
-});
+  process.on('SIGINT', () => server.stop());
+  process.on('SIGTERM', () => server.stop());
 
-server.tool(
-  'hello',
-  'Greets the provided name',
-  { name: z.string().describe('Name to greet') },
-  async ({ name }) => ({
-    content: [
-      { type: 'text', text: `Hello, ${name}!` },
-    ],
-  }),
-);
-
-async function main() {
-  const transport = new StdioServerTransport();
-  process.on('SIGINT', () => shutdown(transport));
-  process.on('SIGTERM', () => shutdown(transport));
-  await server.connect(transport);
-  console.log('STDIO server started');
-}
-
-async function shutdown(transport: StdioServerTransport) {
-  console.error('Shutting down...');
-  await transport.close();
-  process.exit(0);
-}
-
-main().catch((err) => {
-  console.error('Failed to start STDIO server:', err);
-  process.exit(1);
-});
+  await server.start();
+})();

--- a/src/tools/HelloTool.ts
+++ b/src/tools/HelloTool.ts
@@ -1,14 +1,16 @@
 import { MCPTool } from 'mcp-framework';
 import { z } from 'zod';
 
-export default class HelloTool extends MCPTool<{ name: string }> {
+const HelloToolSchema = z.object({
+  name: z.string().describe('Name to greet'),
+});
+
+export default class HelloTool extends MCPTool {
   name = 'hello';
   description = 'Greets the provided name';
-  protected schema = {
-    name: { type: z.string(), description: 'Name to greet' },
-  } as const;
+  schema = HelloToolSchema;
 
-  protected async execute(input: { name: string }) {
-    return { content: [{ type: 'text', text: `Hello, ${input.name}!` }] };
+  async execute(input: { name: string }) {
+    return `Hello, ${input.name}!`;
   }
 }


### PR DESCRIPTION
## Summary
- replace local SDK dependency with published version
- update HelloTool to use Zod schema and simple execute
- switch stdio and SSE servers to load mcp-framework dynamically
- adjust README to mention mcp-framework

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a933533c4832bac62077f7372b8ed