### PR TITLE
Add merge request management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,24 @@ The server exposes the following endpoints:
 - `GET /projects/:id/merge_requests`
 - `GET /projects/:id/merge_requests/:iid`
 - `GET /projects/:id/merge_requests/:iid/discussions`
+- `POST /projects/:id/merge_requests`
+- `PUT /projects/:id/merge_requests/:iid/merge`
+- `PUT /projects/:id/merge_requests/:iid/close`
+- `PUT /projects/:id/merge_requests/:iid/reopen`
+- `PUT /projects/:id/merge_requests/:iid/rebase`
+- `GET /projects/:id/merge_requests/:iid/changes`
+- `GET /projects/:id/merge_requests/:iid/discussions/:discussion_id`
+- `POST /projects/:id/merge_requests/:iid/discussions/:discussion_id/notes`
+- `POST /projects/:id/merge_requests/:iid/discussions`
+- `POST /projects/:id/merge_requests/:iid/discussions/multiline`
+- `DELETE /projects/:id/merge_requests/:iid/discussions/:discussion_id`
+- `PUT /projects/:id/merge_requests/:iid/discussions/:discussion_id`
+- `PUT /projects/:id/merge_requests/:iid/discussions/:discussion_id/resolve`
+- `GET /projects/:id/merge_requests/:iid/notes/:note_id`
+- `POST /projects/:id/merge_requests/:iid/notes`
+- `PUT /projects/:id/merge_requests/:iid/notes/:note_id`
+- `DELETE /projects/:id/merge_requests/:iid/notes/:note_id`
+- `PUT /projects/:id/merge_requests/:iid` (set labels)
 - `GET /projects/:id/files/<path>?ref=<branch>`
 - `GET /projects/:id/branches`
 - `GET /projects/:id/commits`

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -21,11 +21,66 @@ export function createApp() {
     }
   });
 
+  app.post('/projects/:id/merge_requests', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const mr = await svc.createMergeRequest(req.params.id, req.body);
+      res.status(201).json(mr);
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // Get a single merge request
   app.get('/projects/:id/merge_requests/:iid', async (req, res, next: NextFunction) => {
     try {
       const svc = new GitLabService();
       res.json(await svc.getMergeRequest(req.params.id, req.params.iid));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/merge_requests/:iid/merge', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.acceptMergeRequest(req.params.id, req.params.iid));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/merge_requests/:iid/close', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.closeMergeRequest(req.params.id, req.params.iid));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/merge_requests/:iid/reopen', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.reopenMergeRequest(req.params.id, req.params.iid));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/merge_requests/:iid/rebase', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.rebaseMergeRequest(req.params.id, req.params.iid));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/merge_requests/:iid/changes', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.getMergeRequestChanges(req.params.id, req.params.iid));
     } catch (err) {
       next(err);
     }
@@ -97,6 +152,176 @@ export function createApp() {
     try {
       const svc = new GitLabService();
       res.json(await svc.listDiscussions(req.params.id, req.params.iid));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/merge_requests/:iid/discussions/:discussionId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(
+        await svc.getMergeRequestDiscussion(
+          req.params.id,
+          req.params.iid,
+          req.params.discussionId,
+        ),
+      );
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/merge_requests/:iid/discussions/:discussionId/notes', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const note = await svc.addNoteToDiscussion(
+        req.params.id,
+        req.params.iid,
+        req.params.discussionId,
+        req.body,
+      );
+      res.status(201).json(note);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/merge_requests/:iid/discussions', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const discussion = await svc.createMergeRequestDiscussion(
+        req.params.id,
+        req.params.iid,
+        req.body,
+      );
+      res.status(201).json(discussion);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/merge_requests/:iid/discussions/multiline', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const discussion = await svc.createMultilineMergeRequestDiscussion(
+        req.params.id,
+        req.params.iid,
+        req.body,
+      );
+      res.status(201).json(discussion);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.delete('/projects/:id/merge_requests/:iid/discussions/:discussionId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      await svc.deleteMergeRequestDiscussion(
+        req.params.id,
+        req.params.iid,
+        req.params.discussionId,
+      );
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/merge_requests/:iid/discussions/:discussionId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const discussion = await svc.updateMergeRequestDiscussion(
+        req.params.id,
+        req.params.iid,
+        req.params.discussionId,
+        req.body,
+      );
+      res.json(discussion);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/merge_requests/:iid/discussions/:discussionId/resolve', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(
+        await svc.resolveDiscussion(
+          req.params.id,
+          req.params.iid,
+          req.params.discussionId,
+        ),
+      );
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/merge_requests/:iid/notes/:noteId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(
+        await svc.getMergeRequestNote(
+          req.params.id,
+          req.params.iid,
+          req.params.noteId,
+        ),
+      );
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/merge_requests/:iid/notes', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const note = await svc.createMergeRequestNote(
+        req.params.id,
+        req.params.iid,
+        req.body,
+      );
+      res.status(201).json(note);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/merge_requests/:iid/notes/:noteId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(
+        await svc.updateMergeRequestNote(
+          req.params.id,
+          req.params.iid,
+          req.params.noteId,
+          req.body,
+        ),
+      );
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.delete('/projects/:id/merge_requests/:iid/notes/:noteId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      await svc.deleteMergeRequestNote(
+        req.params.id,
+        req.params.iid,
+        req.params.noteId,
+      );
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/merge_requests/:iid', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.setMergeRequestLabels(req.params.id, req.params.iid, req.body));
     } catch (err) {
       next(err);
     }

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -32,6 +32,46 @@ export class GitLabService {
     return data;
   }
 
+  async createMergeRequest(projectId: string | number, payload: Record<string, unknown>) {
+    const { data } = await this.client.post(`/projects/${projectId}/merge_requests`, payload);
+    return data;
+  }
+
+  async acceptMergeRequest(projectId: string | number, mrIid: string | number) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/merge_requests/${mrIid}/merge`,
+    );
+    return data;
+  }
+
+  async closeMergeRequest(projectId: string | number, mrIid: string | number) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/merge_requests/${mrIid}/close`,
+    );
+    return data;
+  }
+
+  async reopenMergeRequest(projectId: string | number, mrIid: string | number) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/merge_requests/${mrIid}/reopen`,
+    );
+    return data;
+  }
+
+  async rebaseMergeRequest(projectId: string | number, mrIid: string | number) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/merge_requests/${mrIid}/rebase`,
+    );
+    return data;
+  }
+
+  async getMergeRequestChanges(projectId: string | number, mrIid: string | number) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/merge_requests/${mrIid}/changes`,
+    );
+    return data;
+  }
+
   async getMergeRequest(projectId: string | number, mrIid: string | number) {
     const { data } = await this.client.get(
       `/projects/${projectId}/merge_requests/${mrIid}`,
@@ -46,6 +86,88 @@ export class GitLabService {
 
   async listDiscussions(projectId: string | number, mrIid: string | number) {
     const { data } = await this.client.get(`/projects/${projectId}/merge_requests/${mrIid}/discussions`);
+    return data;
+  }
+
+  async getMergeRequestDiscussion(
+    projectId: string | number,
+    mrIid: string | number,
+    discussionId: string,
+  ) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/merge_requests/${mrIid}/discussions/${discussionId}`,
+    );
+    return data;
+  }
+
+  async addNoteToDiscussion(
+    projectId: string | number,
+    mrIid: string | number,
+    discussionId: string,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/merge_requests/${mrIid}/discussions/${discussionId}/notes`,
+      payload,
+    );
+    return data;
+  }
+
+  async createMergeRequestDiscussion(
+    projectId: string | number,
+    mrIid: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/merge_requests/${mrIid}/discussions`,
+      payload,
+    );
+    return data;
+  }
+
+  async createMultilineMergeRequestDiscussion(
+    projectId: string | number,
+    mrIid: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/merge_requests/${mrIid}/discussions`,
+      payload,
+    );
+    return data;
+  }
+
+  async deleteMergeRequestDiscussion(
+    projectId: string | number,
+    mrIid: string | number,
+    discussionId: string,
+  ) {
+    await this.client.delete(
+      `/projects/${projectId}/merge_requests/${mrIid}/discussions/${discussionId}`,
+    );
+  }
+
+  async updateMergeRequestDiscussion(
+    projectId: string | number,
+    mrIid: string | number,
+    discussionId: string,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/merge_requests/${mrIid}/discussions/${discussionId}`,
+      payload,
+    );
+    return data;
+  }
+
+  async resolveDiscussion(
+    projectId: string | number,
+    mrIid: string | number,
+    discussionId: string,
+  ) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/merge_requests/${mrIid}/discussions/${discussionId}/resolve`,
+    );
     return data;
   }
 
@@ -94,5 +216,63 @@ export class GitLabService {
       { params: { ref }, responseType: 'text' },
     );
     return data as string;
+  }
+
+  async getMergeRequestNote(
+    projectId: string | number,
+    mrIid: string | number,
+    noteId: string | number,
+  ) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/merge_requests/${mrIid}/notes/${noteId}`,
+    );
+    return data;
+  }
+
+  async createMergeRequestNote(
+    projectId: string | number,
+    mrIid: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/merge_requests/${mrIid}/notes`,
+      payload,
+    );
+    return data;
+  }
+
+  async updateMergeRequestNote(
+    projectId: string | number,
+    mrIid: string | number,
+    noteId: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/merge_requests/${mrIid}/notes/${noteId}`,
+      payload,
+    );
+    return data;
+  }
+
+  async deleteMergeRequestNote(
+    projectId: string | number,
+    mrIid: string | number,
+    noteId: string | number,
+  ) {
+    await this.client.delete(
+      `/projects/${projectId}/merge_requests/${mrIid}/notes/${noteId}`,
+    );
+  }
+
+  async setMergeRequestLabels(
+    projectId: string | number,
+    mrIid: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/merge_requests/${mrIid}`,
+      payload,
+    );
+    return data;
   }
 }

--- a/tests/gitlab.merge_request.manage.test.ts
+++ b/tests/gitlab.merge_request.manage.test.ts
@@ -1,0 +1,264 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab merge request management endpoints', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('creates a merge request', async () => {
+    const payload = { source_branch: 'feat', target_branch: 'main', title: 'MR' };
+    const mockData = { id: 1, title: 'MR' };
+    nock(base)
+      .post('/api/v4/projects/123/merge_requests', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/merge_requests')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('accepts a merge request', async () => {
+    const mockData = { id: 1, merged: true };
+    nock(base)
+      .put('/api/v4/projects/123/merge_requests/1/merge')
+      .reply(200, mockData);
+
+    const res = await request(app).put('/projects/123/merge_requests/1/merge');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('closes a merge request', async () => {
+    const mockData = { id: 1, state: 'closed' };
+    nock(base)
+      .put('/api/v4/projects/123/merge_requests/1/close')
+      .reply(200, mockData);
+
+    const res = await request(app).put('/projects/123/merge_requests/1/close');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('reopens a merge request', async () => {
+    const mockData = { id: 1, state: 'reopened' };
+    nock(base)
+      .put('/api/v4/projects/123/merge_requests/1/reopen')
+      .reply(200, mockData);
+
+    const res = await request(app).put('/projects/123/merge_requests/1/reopen');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('rebases a merge request', async () => {
+    const mockData = { rebase_in_progress: true };
+    nock(base)
+      .put('/api/v4/projects/123/merge_requests/1/rebase')
+      .reply(200, mockData);
+
+    const res = await request(app).put('/projects/123/merge_requests/1/rebase');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns merge request changes', async () => {
+    const mockData = { changes: [] };
+    nock(base)
+      .get('/api/v4/projects/123/merge_requests/1/changes')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/merge_requests/1/changes');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns a single discussion', async () => {
+    const mockData = { id: 'abc', notes: [] };
+    nock(base)
+      .get('/api/v4/projects/123/merge_requests/1/discussions/abc')
+      .reply(200, mockData);
+
+    const res = await request(app).get(
+      '/projects/123/merge_requests/1/discussions/abc',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('adds note to existing discussion', async () => {
+    const payload = { body: 'hi' };
+    const mockData = { id: 'note1', body: 'hi' };
+    nock(base)
+      .post('/api/v4/projects/123/merge_requests/1/discussions/abc/notes', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/merge_requests/1/discussions/abc/notes')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('creates a merge request discussion', async () => {
+    const payload = { body: 'hi' };
+    const mockData = { id: 'abc', notes: [] };
+    nock(base)
+      .post('/api/v4/projects/123/merge_requests/1/discussions', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/merge_requests/1/discussions')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('creates a multiline merge request discussion', async () => {
+    const payload = {
+      body: 'multi',
+      position: {
+        base_sha: 'abc',
+        start_sha: 'abc',
+        head_sha: 'def',
+        old_path: 'file.js',
+        new_path: 'file.js',
+        position_type: 'text',
+        line_range: {
+          start: { type: 'new', line_code: 'LC1', old_line: null, new_line: 1 },
+          end: { type: 'new', line_code: 'LC2', old_line: null, new_line: 2 },
+        },
+      },
+    };
+    const mockData = { id: 'ml', notes: [] };
+    nock(base)
+      .post('/api/v4/projects/123/merge_requests/1/discussions', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/merge_requests/1/discussions/multiline')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a merge request discussion', async () => {
+    nock(base)
+      .delete('/api/v4/projects/123/merge_requests/1/discussions/abc')
+      .reply(204);
+
+    const res = await request(app).delete(
+      '/projects/123/merge_requests/1/discussions/abc',
+    );
+    expect(res.status).toBe(204);
+  });
+
+  it('updates a merge request discussion', async () => {
+    const payload = { body: 'update' };
+    const mockData = { id: 'abc', notes: [] };
+    nock(base)
+      .put('/api/v4/projects/123/merge_requests/1/discussions/abc', payload)
+      .reply(200, mockData);
+
+    const res = await request(app)
+      .put('/projects/123/merge_requests/1/discussions/abc')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('resolves a discussion', async () => {
+    const mockData = { id: 'abc', resolved: true };
+    nock(base)
+      .put('/api/v4/projects/123/merge_requests/1/discussions/abc/resolve')
+      .reply(200, mockData);
+
+    const res = await request(app).put(
+      '/projects/123/merge_requests/1/discussions/abc/resolve',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns a merge request note', async () => {
+    const mockData = { id: 5, body: 'note' };
+    nock(base)
+      .get('/api/v4/projects/123/merge_requests/1/notes/5')
+      .reply(200, mockData);
+
+    const res = await request(app).get(
+      '/projects/123/merge_requests/1/notes/5',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('creates a merge request note', async () => {
+    const payload = { body: 'note' };
+    const mockData = { id: 5, body: 'note' };
+    nock(base)
+      .post('/api/v4/projects/123/merge_requests/1/notes', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/merge_requests/1/notes')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('updates a merge request note', async () => {
+    const payload = { body: 'edit' };
+    const mockData = { id: 5, body: 'edit' };
+    nock(base)
+      .put('/api/v4/projects/123/merge_requests/1/notes/5', payload)
+      .reply(200, mockData);
+
+    const res = await request(app)
+      .put('/projects/123/merge_requests/1/notes/5')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a merge request note', async () => {
+    nock(base)
+      .delete('/api/v4/projects/123/merge_requests/1/notes/5')
+      .reply(204);
+
+    const res = await request(app).delete(
+      '/projects/123/merge_requests/1/notes/5',
+    );
+    expect(res.status).toBe(204);
+  });
+
+  it('sets merge request labels', async () => {
+    const payload = { labels: 'bug,confirmed' };
+    const mockData = { id: 1, labels: ['bug', 'confirmed'] };
+    nock(base)
+      .put('/api/v4/projects/123/merge_requests/1', payload)
+      .reply(200, mockData);
+
+    const res = await request(app)
+      .put('/projects/123/merge_requests/1')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});


### PR DESCRIPTION
## Summary
- implement GitLab merge request management routes and service methods
- document new API routes in README
- add extensive tests for merge request actions
- add support for multiline merge request discussions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa233ceec832b841c751f22e44516