### PR TITLE
Add unresolve discussion endpoint

### DIFF
--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -245,6 +245,24 @@ export function createApp() {
     }
   });
 
+  app.put(
+    '/projects/:id/merge_requests/:iid/discussions/:discussionId/unresolve',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        res.json(
+          await svc.unresolveDiscussion(
+            req.params.id,
+            req.params.iid,
+            req.params.discussionId,
+          ),
+        );
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
   app.get('/projects/:id/merge_requests/:iid/notes/:noteId', async (req, res, next: NextFunction) => {
     try {
       const svc = new GitLabService();

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -159,6 +159,17 @@ export class GitLabService {
     return data;
   }
 
+  async unresolveDiscussion(
+    projectId: string | number,
+    mrIid: string | number,
+    discussionId: string,
+  ) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/merge_requests/${mrIid}/discussions/${discussionId}/unresolve`,
+    );
+    return data;
+  }
+
   async listBranches(projectId: string | number) {
     const { data } = await this.client.get(`/projects/${projectId}/repository/branches`);
     return data;

--- a/tests/gitlab.merge_request.manage.test.ts
+++ b/tests/gitlab.merge_request.manage.test.ts
@@ -164,6 +164,19 @@ describe('GitLab merge request management endpoints', () => {
     expect(res.body).toEqual(mockData);
   });
 
+  it('unresolves a discussion', async () => {
+    const mockData = { id: 'abc', resolved: false };
+    nock(base)
+      .put('/api/v4/projects/123/merge_requests/1/discussions/abc/unresolve')
+      .reply(200, mockData);
+
+    const res = await request(app).put(
+      '/projects/123/merge_requests/1/discussions/abc/unresolve',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
   it('returns a merge request note', async () => {
     const mockData = { id: 5, body: 'note' };
     nock(base)


### PR DESCRIPTION
## Summary
- add unresolveDiscussion in GitLabService
- add /unresolve route to Express app
- test unresolve discussion behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa6fe728c832b973b4f0f7941f718