### PR TITLE
Add GitLab branch management APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ The server exposes the following endpoints:
 - `PUT /projects/:id/merge_requests/:iid` (set labels)
 - `GET /projects/:id/files/<path>?ref=<branch>`
 - `GET /projects/:id/branches`
+- `POST /projects/:id/branches`
+- `GET /projects/:id/branches/:branch`
+- `DELETE /projects/:id/branches/:branch`
 - `GET /projects/:id/commits`
 - `GET /projects/:id/pipelines`
 - `GET /projects/:id/pipelines/:pipeline_id`

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -96,6 +96,41 @@ export function createApp() {
     }
   });
 
+  app.post('/projects/:id/branches', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const branch = await svc.createBranch(req.params.id, req.body);
+      res.status(201).json(branch);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get(
+    '/projects/:id/branches/:branch',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        res.json(await svc.getBranch(req.params.id, req.params.branch));
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.delete(
+    '/projects/:id/branches/:branch',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        await svc.deleteBranch(req.params.id, req.params.branch);
+        res.status(204).end();
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
   // List commits of a project
   app.get('/projects/:id/commits', async (req, res, next: NextFunction) => {
     try {

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -175,6 +175,32 @@ export class GitLabService {
     return data;
   }
 
+  async getBranch(projectId: string | number, branch: string) {
+    const encoded = encodeURIComponent(branch);
+    const { data } = await this.client.get(
+      `/projects/${projectId}/repository/branches/${encoded}`,
+    );
+    return data;
+  }
+
+  async createBranch(
+    projectId: string | number,
+    payload: { branch: string; ref: string },
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/repository/branches`,
+      payload,
+    );
+    return data;
+  }
+
+  async deleteBranch(projectId: string | number, branch: string) {
+    const encoded = encodeURIComponent(branch);
+    await this.client.delete(
+      `/projects/${projectId}/repository/branches/${encoded}`,
+    );
+  }
+
   async listCommits(projectId: string | number) {
     const { data } = await this.client.get(`/projects/${projectId}/repository/commits`);
     return data;

--- a/tests/gitlab.branches.test.ts
+++ b/tests/gitlab.branches.test.ts
@@ -22,4 +22,39 @@ describe('GitLab branches endpoint', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual(mockData);
   });
+
+  it('creates a repository branch', async () => {
+    const payload = { branch: 'feature', ref: 'main' };
+    const mockData = { name: 'feature' };
+    nock(base)
+      .post('/api/v4/projects/123/repository/branches', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/branches')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns a single branch', async () => {
+    const mockData = { name: 'main' };
+    nock(base)
+      .get('/api/v4/projects/123/repository/branches/main')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/branches/main');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a repository branch', async () => {
+    nock(base)
+      .delete('/api/v4/projects/123/repository/branches/old')
+      .reply(204);
+
+    const res = await request(app).delete('/projects/123/branches/old');
+    expect(res.status).toBe(204);
+  });
 });


### PR DESCRIPTION
## Summary
- implement create/get/delete branch methods in GitLabService
- expose new branch endpoints in Express app
- document APIs in README
- test branch creation, retrieval and deletion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab1f80fa0832b88923fa1d6f7305e