### PR TITLE
Add GitLab repository file management

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ The server exposes the following endpoints:
 - `DELETE /projects/:id/merge_requests/:iid/notes/:note_id`
 - `PUT /projects/:id/merge_requests/:iid` (set labels)
 - `GET /projects/:id/files/<path>?ref=<branch>`
+- `POST /projects/:id/files/<path>`
+- `PUT /projects/:id/files/<path>`
+- `DELETE /projects/:id/files/<path>?branch=<branch>&commit_message=<msg>`
+- `GET /projects/:id/files?path=<path>&ref=<branch>`
 - `GET /projects/:id/branches`
 - `POST /projects/:id/branches`
 - `GET /projects/:id/branches/:branch`

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -366,6 +366,47 @@ export function createApp() {
     }
   });
 
+  app.get('/projects/:id/files', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listFiles(req.params.id, req.query));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post(/^\/projects\/(\d+)\/files\/(.+)$/, async (req, res, next: NextFunction) => {
+    try {
+      const params = req.params as unknown as { 0: string; 1: string };
+      const svc = new GitLabService();
+      const file = await svc.createFile(params[0], params[1], req.body);
+      res.status(201).json(file);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put(/^\/projects\/(\d+)\/files\/(.+)$/, async (req, res, next: NextFunction) => {
+    try {
+      const params = req.params as unknown as { 0: string; 1: string };
+      const svc = new GitLabService();
+      res.json(await svc.updateFile(params[0], params[1], req.body));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.delete(/^\/projects\/(\d+)\/files\/(.+)$/, async (req, res, next: NextFunction) => {
+    try {
+      const params = req.params as unknown as { 0: string; 1: string };
+      const svc = new GitLabService();
+      await svc.deleteFile(params[0], params[1], req.query);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // Raw file content – RegExp route avoids path-to-regexp parsing issues
   app.get(/^\/projects\/(\d+)\/files\/(.+)$/, async (req, res, next: NextFunction) => {
     try {

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -243,6 +243,55 @@ export class GitLabService {
     return data as string;
   }
 
+  async createFile(
+    projectId: string | number,
+    filePath: string,
+    payload: Record<string, unknown>,
+  ) {
+    const encodedPath = encodeURIComponent(filePath);
+    const { data } = await this.client.post(
+      `/projects/${projectId}/repository/files/${encodedPath}`,
+      payload,
+    );
+    return data;
+  }
+
+  async updateFile(
+    projectId: string | number,
+    filePath: string,
+    payload: Record<string, unknown>,
+  ) {
+    const encodedPath = encodeURIComponent(filePath);
+    const { data } = await this.client.put(
+      `/projects/${projectId}/repository/files/${encodedPath}`,
+      payload,
+    );
+    return data;
+  }
+
+  async deleteFile(
+    projectId: string | number,
+    filePath: string,
+    params: Record<string, unknown>,
+  ) {
+    const encodedPath = encodeURIComponent(filePath);
+    await this.client.delete(
+      `/projects/${projectId}/repository/files/${encodedPath}`,
+      { params },
+    );
+  }
+
+  async listFiles(
+    projectId: string | number,
+    params: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/repository/tree`,
+      { params },
+    );
+    return data;
+  }
+
   async getMergeRequestNote(
     projectId: string | number,
     mrIid: string | number,

--- a/tests/gitlab.files.test.ts
+++ b/tests/gitlab.files.test.ts
@@ -24,4 +24,73 @@ describe('GitLab File fetch endpoint', () => {
     expect(res.status).toBe(200);
     expect(res.text).toBe(fileContent);
   });
+
+  it('creates a file in the repository', async () => {
+    const payload = {
+      branch: 'main',
+      content: 'hello',
+      commit_message: 'add file',
+    };
+    const encodedPath = encodeURIComponent('new/file.txt');
+    const mockData = { file_path: 'new/file.txt' };
+    nock(base)
+      .post(`/api/v4/projects/123/repository/files/${encodedPath}`, payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/files/new/file.txt')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('updates a repository file', async () => {
+    const payload = {
+      branch: 'main',
+      content: 'updated',
+      commit_message: 'update file',
+    };
+    const encodedPath = encodeURIComponent('src/index.ts');
+    const mockData = { file_path: 'src/index.ts' };
+    nock(base)
+      .put(`/api/v4/projects/123/repository/files/${encodedPath}`, payload)
+      .reply(200, mockData);
+
+    const res = await request(app)
+      .put('/projects/123/files/src/index.ts')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a repository file', async () => {
+    const payload = {
+      branch: 'main',
+      commit_message: 'remove file',
+    };
+    const encodedPath = encodeURIComponent('old/file.txt');
+    nock(base)
+      .delete(`/api/v4/projects/123/repository/files/${encodedPath}`)
+      .query(payload)
+      .reply(204);
+
+    const res = await request(app)
+      .delete('/projects/123/files/old/file.txt')
+      .query(payload);
+    expect(res.status).toBe(204);
+  });
+
+  it('lists repository files', async () => {
+    const mockData = [{ id: 'file1' }];
+    nock(base)
+      .get('/api/v4/projects/123/repository/tree')
+      .query({ path: 'src', ref: 'main' })
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/files?path=src&ref=main');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
 });


### PR DESCRIPTION
## Summary
- extend GitLabService with createFile, updateFile, deleteFile and listFiles
- expose REST endpoints in createApp for managing repository files
- document new routes in README
- test new API behaviour with Jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab3cd75c0832b9caa0d288abe326b