### PR TITLE
Add GitLab groups and extended issue API

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ The server exposes the following endpoints:
 - `GET /projects/:id/pipelines/:pipeline_id`
 - `GET /projects/:id/issues`
 - `POST /projects/:id/issues`
+- `GET /projects/:id/issues/:issue_id`
+- `PUT /projects/:id/issues/:issue_id`
+- `PUT /projects/:id/issues/:issue_id/close`
+- `PUT /projects/:id/issues/:issue_id/reopen`
+- `POST /groups`
+- `GET /groups/:id`
+- `DELETE /groups/:id`
+- `GET /groups/:id/members`
 
 Additionally `/tool/hello` demonstrates how to add custom tools.
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -11,6 +11,48 @@ export function createApp() {
     res.status(200).json({ status: 'ok' });
   });
 
+  app.post('/groups', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const group = await svc.createGroup(req.body);
+      res.status(201).json(group);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/groups/:id', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.getGroup(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.delete('/groups/:id', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const result = await svc.deleteGroup(req.params.id);
+      if (result) {
+        res.status(202).json(result);
+      } else {
+        res.status(202).end();
+      }
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/groups/:id/members', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listGroupMembers(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // List merge requests
   app.get('/projects/:id/merge_requests', async (req, res, next: NextFunction) => {
     try {
@@ -177,6 +219,44 @@ export function createApp() {
       const svc = new GitLabService();
       const issue = await svc.createIssue(req.params.id, req.body);
       res.status(201).json(issue);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/issues/:iid', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.getIssue(req.params.id, req.params.iid));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/issues/:iid', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(
+        await svc.updateIssue(req.params.id, req.params.iid, req.body),
+      );
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/issues/:iid/close', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.closeIssue(req.params.id, req.params.iid));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/issues/:iid/reopen', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.reopenIssue(req.params.id, req.params.iid));
     } catch (err) {
       next(err);
     }

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -520,11 +520,15 @@ export function createApp() {
     const id = randomUUID();
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
     res.flushHeaders();
 
     // inform client of the message endpoint
     res.write(`event: endpoint\n`);
     res.write(`data: /messages/${id}\n\n`);
+    if (typeof (res as any).flush === 'function') {
+      (res as any).flush();
+    }
 
     const keepAlive = setInterval(() => {
       res.write(`: keep-alive ${Date.now()}\n\n`);
@@ -547,6 +551,9 @@ export function createApp() {
     }
     client.res.write(`event: message\n`);
     client.res.write(`data: ${JSON.stringify(req.body)}\n\n`);
+    if (typeof (client.res as any).flush === 'function') {
+      (client.res as any).flush();
+    }
     res.status(204).end();
   });
 

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -234,6 +234,44 @@ export class GitLabService {
     return data;
   }
 
+  async getIssue(
+    projectId: string | number,
+    issueIid: string | number,
+  ): Promise<IssueResponse> {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/issues/${issueIid}`,
+    );
+    return data;
+  }
+
+  async updateIssue(
+    projectId: string | number,
+    issueIid: string | number,
+    payload: Record<string, unknown>,
+  ): Promise<IssueResponse> {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/issues/${issueIid}`,
+      payload,
+    );
+    return data;
+  }
+
+  async closeIssue(projectId: string | number, issueIid: string | number) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/issues/${issueIid}`,
+      { state_event: 'close' },
+    );
+    return data;
+  }
+
+  async reopenIssue(projectId: string | number, issueIid: string | number) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/issues/${issueIid}`,
+      { state_event: 'reopen' },
+    );
+    return data;
+  }
+
   async getFile(projectId: string | number, filePath: string, ref: string) {
     const encodedPath = encodeURIComponent(filePath);
     const { data } = await this.client.get(
@@ -347,6 +385,26 @@ export class GitLabService {
       `/projects/${projectId}/merge_requests/${mrIid}`,
       payload,
     );
+    return data;
+  }
+
+  async createGroup(payload: Record<string, unknown>) {
+    const { data } = await this.client.post('/groups', payload);
+    return data;
+  }
+
+  async getGroup(groupId: string | number) {
+    const { data } = await this.client.get(`/groups/${groupId}`);
+    return data;
+  }
+
+  async deleteGroup(groupId: string | number) {
+    const { data } = await this.client.delete(`/groups/${groupId}`);
+    return data;
+  }
+
+  async listGroupMembers(groupId: string | number) {
+    const { data } = await this.client.get(`/groups/${groupId}/members`);
     return data;
   }
 }

--- a/tests/gitlab.groups.test.ts
+++ b/tests/gitlab.groups.test.ts
@@ -1,0 +1,60 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab groups endpoints', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('creates a group', async () => {
+    const payload = { name: 'Test', path: 'test' };
+    const mockData = { id: 5, name: 'Test' };
+    nock(base)
+      .post('/api/v4/groups', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/groups')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns a group', async () => {
+    const mockData = { id: 5, name: 'Test' };
+    nock(base)
+      .get('/api/v4/groups/5')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/groups/5');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a group', async () => {
+    nock(base)
+      .delete('/api/v4/groups/5')
+      .reply(202);
+
+    const res = await request(app).delete('/groups/5');
+    expect(res.status).toBe(202);
+  });
+
+  it('lists group members', async () => {
+    const mockData = [{ id: 1, name: 'Alice' }];
+    nock(base)
+      .get('/api/v4/groups/5/members')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/groups/5/members');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});

--- a/tests/gitlab.issues.test.ts
+++ b/tests/gitlab.issues.test.ts
@@ -37,4 +37,51 @@ describe('GitLab issues endpoints', () => {
     expect(res.status).toBe(201);
     expect(res.body).toEqual(mockData);
   });
+it('returns a single issue', async () => {
+  const mockData = { id: 3, title: 'Issue3' };
+  nock(base)
+    .get('/api/v4/projects/123/issues/3')
+    .reply(200, mockData);
+
+  const res = await request(app).get('/projects/123/issues/3');
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual(mockData);
+});
+
+it('updates an issue', async () => {
+  const payload = { title: 'Updated issue' };
+  const mockData = { id: 3, title: 'Updated issue' };
+  nock(base)
+    .put('/api/v4/projects/123/issues/3', payload)
+    .reply(200, mockData);
+
+  const res = await request(app)
+    .put('/projects/123/issues/3')
+    .send(payload)
+    .set('Content-Type', 'application/json');
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual(mockData);
+});
+
+it('closes an issue', async () => {
+  const mockData = { id: 3, state: 'closed' };
+  nock(base)
+    .put('/api/v4/projects/123/issues/3', { state_event: 'close' })
+    .reply(200, mockData);
+
+  const res = await request(app).put('/projects/123/issues/3/close');
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual(mockData);
+});
+
+it('reopens an issue', async () => {
+  const mockData = { id: 3, state: 'reopened' };
+  nock(base)
+    .put('/api/v4/projects/123/issues/3', { state_event: 'reopen' })
+    .reply(200, mockData);
+
+  const res = await request(app).put('/projects/123/issues/3/reopen');
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual(mockData);
+});
 });

--- a/tests/sse.test.ts
+++ b/tests/sse.test.ts
@@ -49,4 +49,23 @@ describe('SSE transport', () => {
       req.end();
     });
   });
+
+  it('keeps the connection alive', (done) => {
+    const app = createApp();
+    const server = app.listen(() => {
+      const { port } = server.address() as any;
+      http
+        .get({
+          hostname: '127.0.0.1',
+          port,
+          path: '/sse',
+          headers: { Accept: 'text/event-stream' },
+        })
+        .on('response', (res) => {
+          expect(res.headers.connection).toBe('keep-alive');
+          res.destroy();
+          server.close(() => done());
+        });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- support creating/deleting/getting GitLab groups and listing group members
- extend issues API with get/update/close/reopen helpers
- expose new endpoints via express app
- test new group and issue routes
- document added endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab56ff660832b93edc1dd6911f2db