### PR TITLE
Add pipeline management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ The server exposes the following endpoints:
 - `GET /projects/:id/commits`
 - `GET /projects/:id/pipelines`
 - `GET /projects/:id/pipelines/:pipeline_id`
+- `POST /projects/:id/pipelines`
+- `POST /projects/:id/pipelines/:pipeline_id/cancel`
+- `POST /projects/:id/pipelines/:pipeline_id/retry`
+- `DELETE /projects/:id/pipelines/:pipeline_id`
+- `GET /projects/:id/pipelines/:pipeline_id/jobs`
+- `GET /projects/:id/pipelines/:pipeline_id/artifacts`
 - `GET /projects/:id/issues`
 - `POST /projects/:id/issues`
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -161,6 +161,77 @@ export function createApp() {
     }
   });
 
+  app.post('/projects/:id/pipelines', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const pipeline = await svc.createPipeline(req.params.id, req.body);
+      res.status(201).json(pipeline);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post(
+    '/projects/:id/pipelines/:pipelineId/cancel',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        const result = await svc.cancelPipeline(
+          req.params.id,
+          req.params.pipelineId,
+        );
+        res.json(result);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.post(
+    '/projects/:id/pipelines/:pipelineId/retry',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        const result = await svc.retryPipeline(
+          req.params.id,
+          req.params.pipelineId,
+        );
+        res.json(result);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.delete('/projects/:id/pipelines/:pipelineId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      await svc.deletePipeline(req.params.id, req.params.pipelineId);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/pipelines/:pipelineId/jobs', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.getPipelineJobs(req.params.id, req.params.pipelineId));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/pipelines/:pipelineId/artifacts', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const data = await svc.downloadPipelineArtifacts(req.params.id, req.params.pipelineId);
+      res.send(data);
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // List issues of a project
   app.get('/projects/:id/issues', async (req, res, next: NextFunction) => {
     try {

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -218,6 +218,54 @@ export class GitLabService {
     return data;
   }
 
+  async createPipeline(
+    projectId: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/pipelines`,
+      payload,
+    );
+    return data;
+  }
+
+  async cancelPipeline(projectId: string | number, pipelineId: string | number) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/pipelines/${pipelineId}/cancel`,
+    );
+    return data;
+  }
+
+  async retryPipeline(projectId: string | number, pipelineId: string | number) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/pipelines/${pipelineId}/retry`,
+    );
+    return data;
+  }
+
+  async deletePipeline(projectId: string | number, pipelineId: string | number) {
+    await this.client.delete(
+      `/projects/${projectId}/pipelines/${pipelineId}`,
+    );
+  }
+
+  async getPipelineJobs(projectId: string | number, pipelineId: string | number) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/pipelines/${pipelineId}/jobs`,
+    );
+    return data;
+  }
+
+  async downloadPipelineArtifacts(
+    projectId: string | number,
+    pipelineId: string | number,
+  ) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/pipelines/${pipelineId}/artifacts`,
+    );
+    return data;
+  }
+
   async listIssues(projectId: string | number): Promise<IssueResponse[]> {
     const { data } = await this.client.get(`/projects/${projectId}/issues`);
     return data;

--- a/tests/gitlab.pipelines.test.ts
+++ b/tests/gitlab.pipelines.test.ts
@@ -34,4 +34,72 @@ describe('GitLab pipelines endpoints', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual(mockData);
   });
+
+  it('creates a pipeline', async () => {
+    const payload = { ref: 'main' };
+    const mockData = { id: 2, status: 'pending' };
+    nock(base)
+      .post('/api/v4/projects/123/pipelines', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/pipelines')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('cancels a pipeline', async () => {
+    const mockData = { id: 1, status: 'canceled' };
+    nock(base)
+      .post('/api/v4/projects/123/pipelines/1/cancel')
+      .reply(200, mockData);
+
+    const res = await request(app).post('/projects/123/pipelines/1/cancel');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('retries a pipeline', async () => {
+    const mockData = { id: 1, status: 'pending' };
+    nock(base)
+      .post('/api/v4/projects/123/pipelines/1/retry')
+      .reply(200, mockData);
+
+    const res = await request(app).post('/projects/123/pipelines/1/retry');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a pipeline', async () => {
+    nock(base)
+      .delete('/api/v4/projects/123/pipelines/1')
+      .reply(204);
+
+    const res = await request(app).delete('/projects/123/pipelines/1');
+    expect(res.status).toBe(204);
+  });
+
+  it('returns pipeline jobs', async () => {
+    const mockData = [{ id: 1, name: 'build' }];
+    nock(base)
+      .get('/api/v4/projects/123/pipelines/1/jobs')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/pipelines/1/jobs');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('downloads pipeline artifacts', async () => {
+    const artifact = 'zipcontent';
+    nock(base)
+      .get('/api/v4/projects/123/pipelines/1/artifacts')
+      .reply(200, artifact);
+
+    const res = await request(app).get('/projects/123/pipelines/1/artifacts');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe(artifact);
+  });
 });


### PR DESCRIPTION
## Summary
- extend GitLab pipeline support with create, cancel, retry, delete, jobs, artifacts endpoints
- implement corresponding methods in `GitLabService`
- document new endpoints in README
- test pipeline management

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab754a8a0832bbfbbd25d190072ab