### PR TITLE
Add project search, releases and tags endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ connection lifecycle.
 
 The server exposes the following endpoints:
 
+- `GET /projects`
+- `GET /projects/search?q=<query>`
 - `GET /projects/:id`
 - `GET /projects/:id/merge_requests`
 - `GET /projects/:id/merge_requests/:iid`
@@ -171,6 +173,15 @@ The server exposes the following endpoints:
 - `DELETE /projects/:id/pipelines/:pipeline_id`
 - `GET /projects/:id/pipelines/:pipeline_id/jobs`
 - `GET /projects/:id/pipelines/:pipeline_id/artifacts`
+- `GET /projects/:id/releases`
+- `GET /projects/:id/releases/:tag`
+- `POST /projects/:id/releases`
+- `PUT /projects/:id/releases/:tag`
+- `DELETE /projects/:id/releases/:tag`
+- `GET /projects/:id/tags`
+- `GET /projects/:id/tags/:tag`
+- `POST /projects/:id/tags`
+- `DELETE /projects/:id/tags/:tag`
 - `GET /projects/:id/issues`
 - `POST /projects/:id/issues`
 - `GET /projects/:id/issues/:issue_id`

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -573,6 +573,110 @@ export function createApp() {
     }
   });
 
+  app.get('/projects', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listProjects(req.query));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/search', async (req, res, next: NextFunction) => {
+    try {
+      const q = typeof req.query.q === 'string' ? req.query.q : '';
+      const svc = new GitLabService();
+      res.json(await svc.searchProjects(q));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/releases', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listReleases(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/releases/:tag', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.getRelease(req.params.id, req.params.tag));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/releases', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const release = await svc.createRelease(req.params.id, req.body);
+      res.status(201).json(release);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/releases/:tag', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.updateRelease(req.params.id, req.params.tag, req.body));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.delete('/projects/:id/releases/:tag', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      await svc.deleteRelease(req.params.id, req.params.tag);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/tags', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listTags(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/tags/:tag', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.getTag(req.params.id, req.params.tag));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/tags', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const tag = await svc.createTag(req.params.id, req.body);
+      res.status(201).json(tag);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.delete('/projects/:id/tags/:tag', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      await svc.deleteTag(req.params.id, req.params.tag);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // Get project metadata
   app.get('/projects/:id', async (req, res, next: NextFunction) => {
     try {

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -84,6 +84,16 @@ export class GitLabService {
     return data;
   }
 
+  async listProjects(params: Record<string, unknown> = {}) {
+    const { data } = await this.client.get('/projects', { params });
+    return data;
+  }
+
+  async searchProjects(query: string) {
+    const { data } = await this.client.get('/projects', { params: { search: query } });
+    return data;
+  }
+
   async listDiscussions(projectId: string | number, mrIid: string | number) {
     const { data } = await this.client.get(`/projects/${projectId}/merge_requests/${mrIid}/discussions`);
     return data;
@@ -454,5 +464,53 @@ export class GitLabService {
   async listGroupMembers(groupId: string | number) {
     const { data } = await this.client.get(`/groups/${groupId}/members`);
     return data;
+  }
+
+  async listReleases(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/releases`);
+    return data;
+  }
+
+  async getRelease(projectId: string | number, tagName: string) {
+    const encoded = encodeURIComponent(tagName);
+    const { data } = await this.client.get(`/projects/${projectId}/releases/${encoded}`);
+    return data;
+  }
+
+  async createRelease(projectId: string | number, payload: Record<string, unknown>) {
+    const { data } = await this.client.post(`/projects/${projectId}/releases`, payload);
+    return data;
+  }
+
+  async updateRelease(projectId: string | number, tagName: string, payload: Record<string, unknown>) {
+    const encoded = encodeURIComponent(tagName);
+    const { data } = await this.client.put(`/projects/${projectId}/releases/${encoded}`, payload);
+    return data;
+  }
+
+  async deleteRelease(projectId: string | number, tagName: string) {
+    const encoded = encodeURIComponent(tagName);
+    await this.client.delete(`/projects/${projectId}/releases/${encoded}`);
+  }
+
+  async listTags(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/repository/tags`);
+    return data;
+  }
+
+  async getTag(projectId: string | number, tagName: string) {
+    const encoded = encodeURIComponent(tagName);
+    const { data } = await this.client.get(`/projects/${projectId}/repository/tags/${encoded}`);
+    return data;
+  }
+
+  async createTag(projectId: string | number, payload: Record<string, unknown>) {
+    const { data } = await this.client.post(`/projects/${projectId}/repository/tags`, payload);
+    return data;
+  }
+
+  async deleteTag(projectId: string | number, tagName: string) {
+    const encoded = encodeURIComponent(tagName);
+    await this.client.delete(`/projects/${projectId}/repository/tags/${encoded}`);
   }
 }

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -90,8 +90,7 @@ export class GitLabService {
   }
 
   async searchProjects(query: string) {
-    const { data } = await this.client.get('/projects', { params: { search: query } });
-    return data;
+    return this.listProjects({ search: query });
   }
 
   async listDiscussions(projectId: string | number, mrIid: string | number) {

--- a/tests/gitlab.project.test.ts
+++ b/tests/gitlab.project.test.ts
@@ -22,4 +22,27 @@ describe('GitLab project endpoint', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual(mockData);
   });
+
+  it('returns projects list', async () => {
+    const mockData = [{ id: 1, name: 'proj' }];
+    nock(base)
+      .get('/api/v4/projects')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('searches projects', async () => {
+    const mockData = [{ id: 1, name: 'proj' }];
+    nock(base)
+      .get('/api/v4/projects')
+      .query({ search: 'test' })
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/search?q=test');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
 });

--- a/tests/gitlab.releases.test.ts
+++ b/tests/gitlab.releases.test.ts
@@ -1,0 +1,76 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab releases endpoints', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('creates a release', async () => {
+    const payload = { name: 'v1.0', tag_name: 'v1.0' };
+    const mockData = { name: 'v1.0' };
+    nock(base)
+      .post('/api/v4/projects/123/releases', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/releases')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns a release', async () => {
+    const mockData = { name: 'v1.0' };
+    nock(base)
+      .get('/api/v4/projects/123/releases/v1.0')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/releases/v1.0');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns releases list', async () => {
+    const mockData = [{ name: 'v1.0' }];
+    nock(base)
+      .get('/api/v4/projects/123/releases')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/releases');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('updates a release', async () => {
+    const payload = { name: 'v1.0', description: 'update' };
+    const mockData = { name: 'v1.0', description: 'update' };
+    nock(base)
+      .put('/api/v4/projects/123/releases/v1.0', payload)
+      .reply(200, mockData);
+
+    const res = await request(app)
+      .put('/projects/123/releases/v1.0')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a release', async () => {
+    nock(base)
+      .delete('/api/v4/projects/123/releases/v1.0')
+      .reply(204);
+
+    const res = await request(app).delete('/projects/123/releases/v1.0');
+    expect(res.status).toBe(204);
+  });
+});

--- a/tests/gitlab.tags.test.ts
+++ b/tests/gitlab.tags.test.ts
@@ -1,0 +1,61 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab tags endpoints', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('creates a tag', async () => {
+    const payload = { tag_name: 'v1.0', ref: 'main' };
+    const mockData = { name: 'v1.0' };
+    nock(base)
+      .post('/api/v4/projects/123/repository/tags', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/tags')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns a tag', async () => {
+    const mockData = { name: 'v1.0' };
+    nock(base)
+      .get('/api/v4/projects/123/repository/tags/v1.0')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/tags/v1.0');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('returns tags list', async () => {
+    const mockData = [{ name: 'v1.0' }];
+    nock(base)
+      .get('/api/v4/projects/123/repository/tags')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/tags');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a tag', async () => {
+    nock(base)
+      .delete('/api/v4/projects/123/repository/tags/v1.0')
+      .reply(204);
+
+    const res = await request(app).delete('/projects/123/tags/v1.0');
+    expect(res.status).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary
- extend GitLabService with project search, release and tag helpers
- expose new REST routes in `createApp`
- document the extra endpoints
- test projects search, releases and tags functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab966bbf8832babe0e15ea79898a0