### PR TITLE
Implement multiple GitLab API groups

### DIFF
--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -11,6 +11,15 @@ export function createApp() {
     res.status(200).json({ status: 'ok' });
   });
 
+  app.get('/personal_access_tokens', async (_req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listPersonalAccessTokens());
+    } catch (err) {
+      next(err);
+    }
+  });
+
   app.post('/groups', async (req, res, next: NextFunction) => {
     try {
       const svc = new GitLabService();
@@ -48,6 +57,51 @@ export function createApp() {
     try {
       const svc = new GitLabService();
       res.json(await svc.listGroupMembers(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/groups/:id/epics', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listGroupEpics(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/access_tokens', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listProjectAccessTokens(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/access_requests', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listProjectAccessRequests(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/groups/:id/access_tokens', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listGroupAccessTokens(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/groups/:id/access_requests', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listGroupAccessRequests(req.params.id));
     } catch (err) {
       next(err);
     }
@@ -172,6 +226,128 @@ export function createApp() {
       }
     },
   );
+
+  app.get('/projects/:id/deploy_keys', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listDeployKeys(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/deploy_tokens', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const token = await svc.createDeployToken(req.params.id, req.body);
+      res.status(201).json(token);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/deployments', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listDeployments(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/registry/repositories', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listRegistryRepositories(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/registry/protection/repository/rules', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listRegistryProtectionRules(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/feature_flags', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const flag = await svc.createFeatureFlag(req.params.id, req.body);
+      res.status(201).json(flag);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/feature_flags', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listFeatureFlags(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.delete('/projects/:id/feature_flags/:flagId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      await svc.deleteFeatureFlag(req.params.id, req.params.flagId);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/freeze_periods', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listFreezePeriods(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/variables', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const variable = await svc.createProjectVariable(req.params.id, req.body);
+      res.status(201).json(variable);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/variables', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listProjectVariables(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.delete('/projects/:id/variables/:key', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      await svc.deleteProjectVariable(req.params.id, req.params.key);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/protected_branches', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listProtectedBranches(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  });
 
   // List commits of a project
   app.get('/projects/:id/commits', async (req, res, next: NextFunction) => {
@@ -672,6 +848,16 @@ export function createApp() {
       const svc = new GitLabService();
       await svc.deleteTag(req.params.id, req.params.tag);
       res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/api/graphql', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const data = await svc.graphqlQuery(req.body);
+      res.json(data);
     } catch (err) {
       next(err);
     }

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -512,4 +512,98 @@ export class GitLabService {
     const encoded = encodeURIComponent(tagName);
     await this.client.delete(`/projects/${projectId}/repository/tags/${encoded}`);
   }
+  async listProjectAccessTokens(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/access_tokens`);
+    return data;
+  }
+
+  async listProjectAccessRequests(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/access_requests`);
+    return data;
+  }
+
+  async listGroupAccessTokens(groupId: string | number) {
+    const { data } = await this.client.get(`/groups/${groupId}/access_tokens`);
+    return data;
+  }
+
+  async listGroupAccessRequests(groupId: string | number) {
+    const { data } = await this.client.get(`/groups/${groupId}/access_requests`);
+    return data;
+  }
+
+  async listGroupEpics(groupId: string | number) {
+    const { data } = await this.client.get(`/groups/${groupId}/epics`);
+    return data;
+  }
+  async listDeployKeys(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/deploy_keys`);
+    return data;
+  }
+
+  async createDeployToken(projectId: string | number, payload: Record<string, unknown>) {
+    const { data } = await this.client.post(`/projects/${projectId}/deploy_tokens`, payload);
+    return data;
+  }
+
+  async listDeployments(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/deployments`);
+    return data;
+  }
+  async listRegistryRepositories(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/registry/repositories`);
+    return data;
+  }
+
+  async listRegistryProtectionRules(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/registry/protection/repository/rules`);
+    return data;
+  }
+  async createFeatureFlag(projectId: string | number, payload: Record<string, unknown>) {
+    const { data } = await this.client.post(`/projects/${projectId}/feature_flags`, payload);
+    return data;
+  }
+
+  async listFeatureFlags(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/feature_flags`);
+    return data;
+  }
+
+  async deleteFeatureFlag(projectId: string | number, flagId: string | number) {
+    await this.client.delete(`/projects/${projectId}/feature_flags/${flagId}`);
+  }
+
+  async listFreezePeriods(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/freeze_periods`);
+    return data;
+  }
+  async createProjectVariable(projectId: string | number, payload: Record<string, unknown>) {
+    const { data } = await this.client.post(`/projects/${projectId}/variables`, payload);
+    return data;
+  }
+
+  async listProjectVariables(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/variables`);
+    return data;
+  }
+
+  async deleteProjectVariable(projectId: string | number, key: string) {
+    const encoded = encodeURIComponent(key);
+    await this.client.delete(`/projects/${projectId}/variables/${encoded}`);
+  }
+
+  async listProtectedBranches(projectId: string | number) {
+    const { data } = await this.client.get(`/projects/${projectId}/protected_branches`);
+    return data;
+  }
+
+  async listPersonalAccessTokens() {
+    const { data } = await this.client.get(`/personal_access_tokens`);
+    return data;
+  }
+
+  async graphqlQuery(query: Record<string, unknown>) {
+    const { data } = await this.client.post(`/graphql`, query);
+    return data;
+  }
 }

--- a/tests/gitlab.access_tokens.test.ts
+++ b/tests/gitlab.access_tokens.test.ts
@@ -1,0 +1,59 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab access tokens and requests', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('lists project access tokens', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/projects/123/access_tokens')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/access_tokens');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('lists project access requests', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/projects/123/access_requests')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/access_requests');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('lists group access tokens', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/groups/5/access_tokens')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/groups/5/access_tokens');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('lists group access requests', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/groups/5/access_requests')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/groups/5/access_requests');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});

--- a/tests/gitlab.deploy.test.ts
+++ b/tests/gitlab.deploy.test.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab deploy keys, tokens and deployments', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('lists deploy keys', async () => {
+    const mockData = [{ id: 1, title: 'key' }];
+    nock(base)
+      .get('/api/v4/projects/123/deploy_keys')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/deploy_keys');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('creates a deploy token', async () => {
+    const payload = { name: 'token', scopes: ['read_repository'] };
+    const mockData = { id: 2, name: 'token' };
+    nock(base)
+      .post('/api/v4/projects/123/deploy_tokens', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/deploy_tokens')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('lists deployments', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/projects/123/deployments')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/deployments');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});

--- a/tests/gitlab.feature_flags.test.ts
+++ b/tests/gitlab.feature_flags.test.ts
@@ -1,0 +1,61 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab feature flags and freeze periods', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('creates a feature flag', async () => {
+    const payload = { name: 'flag' };
+    const mockData = { id: 1, name: 'flag' };
+    nock(base)
+      .post('/api/v4/projects/123/feature_flags', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/feature_flags')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('lists feature flags', async () => {
+    const mockData = [{ id: 1, name: 'flag' }];
+    nock(base)
+      .get('/api/v4/projects/123/feature_flags')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/feature_flags');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a feature flag', async () => {
+    nock(base)
+      .delete('/api/v4/projects/123/feature_flags/1')
+      .reply(204);
+
+    const res = await request(app).delete('/projects/123/feature_flags/1');
+    expect(res.status).toBe(204);
+  });
+
+  it('lists freeze periods', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/projects/123/freeze_periods')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/freeze_periods');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});

--- a/tests/gitlab.misc.test.ts
+++ b/tests/gitlab.misc.test.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab misc endpoints', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('lists group epics', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/groups/5/epics')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/groups/5/epics');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('lists personal access tokens', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/personal_access_tokens')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/personal_access_tokens');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('proxies GraphQL', async () => {
+    const query = '{ projects { id } }';
+    const mockData = { data: { projects: [] } };
+    nock(base)
+      .post('/api/v4/graphql', { query })
+      .reply(200, mockData);
+
+    const res = await request(app)
+      .post('/api/graphql')
+      .send({ query })
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});

--- a/tests/gitlab.registry.test.ts
+++ b/tests/gitlab.registry.test.ts
@@ -1,0 +1,37 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab container registry', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('lists registry repositories', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/projects/123/registry/repositories')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/registry/repositories');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('lists registry protection rules', async () => {
+    const mockData = [{ id: 1 }];
+    nock(base)
+      .get('/api/v4/projects/123/registry/protection/repository/rules')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/registry/protection/repository/rules');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});

--- a/tests/gitlab.variables.test.ts
+++ b/tests/gitlab.variables.test.ts
@@ -1,0 +1,61 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab project variables and protected branches', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('adds a project variable', async () => {
+    const payload = { key: 'VAR', value: '1' };
+    const mockData = { key: 'VAR', value: '1' };
+    nock(base)
+      .post('/api/v4/projects/123/variables', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/variables')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('lists project variables', async () => {
+    const mockData = [{ key: 'VAR', value: '1' }];
+    nock(base)
+      .get('/api/v4/projects/123/variables')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/variables');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a project variable', async () => {
+    nock(base)
+      .delete('/api/v4/projects/123/variables/VAR')
+      .reply(204);
+
+    const res = await request(app).delete('/projects/123/variables/VAR');
+    expect(res.status).toBe(204);
+  });
+
+  it('lists protected branches', async () => {
+    const mockData = [{ name: 'main' }];
+    nock(base)
+      .get('/api/v4/projects/123/protected_branches')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/protected_branches');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});


### PR DESCRIPTION
## Summary
- add access tokens & requests routes
- implement deploy keys/tokens and deployments
- expose container registry and protection rules
- add feature flags and freeze period support
- support variables and protected branches
- add group epics, personal access tokens and GraphQL passthrough
- cover all new endpoints with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684abf25de14832bbc039546c1f8ca72