### PR TITLE
Add CLI filtering for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,52 @@ Set the following variables to connect to your GitLab instance:
 ```bash
 GITLAB_BASE_URL=https://gitlab.example.com/api/v4
 GITLAB_TOKEN=your-private-token
+# optionally limit exposed tools
+# use a comma-separated list
+# TOOLS_INCLUDE=projects,merge_requests
+# or exclude certain tools
+# TOOLS_EXCLUDE=pipelines
+# TOOLS_INCLUDE takes precedence if both are set
 ```
+
+### Filtering Available Tools
+
+By default the server loads all GitLab tools. To restrict the available set you
+can provide an **include** or **exclude** list:
+
+- **Environment variables** – set `TOOLS_INCLUDE` or `TOOLS_EXCLUDE` to a comma-
+  separated list. If both are defined, `TOOLS_INCLUDE` wins.
+
+  ```bash
+  TOOLS_INCLUDE=projects,merge_requests npm run start:mcp
+  # or
+  TOOLS_EXCLUDE=pipelines npm run start:mcp
+  ```
+
+- **Programmatic API** – pass `includes` or `excludes` to `createMcpServer()`:
+
+  ```ts
+  import { createMcpServer } from 'mcp-server-extended-gitlab';
+
+  const server = await createMcpServer({ includes: ['projects', 'merge_requests'] });
+  await server.start();
+  ```
+
+- **Config file** – supply a JSON file when creating the server. Use the
+  `configPath` option pointing to a file like:
+
+  ```json
+  {
+    "includes": ["projects", "merge_requests"]
+  }
+  ```
+
+  ```ts
+  const server = await createMcpServer({ configPath: 'mcp.config.json' });
+  ```
+
+Use this when embedding the server in another application. Remember that the
+include list overrides the exclude list if both are supplied.
 
 
 
@@ -153,6 +198,7 @@ npm run start:mcp
 ```
 
 It listens on port `3000` (or `PORT`). Ensure `GITLAB_BASE_URL` and `GITLAB_TOKEN` are configured.
+Use `TOOLS_INCLUDE` or `TOOLS_EXCLUDE` to control which tools are loaded.
 
 ### Claude Desktop
 
@@ -167,7 +213,10 @@ It listens on port `3000` (or `PORT`). Ensure `GITLAB_BASE_URL` and `GITLAB_TOKE
   "mcpServers": {
     "gitlab-server": {
       "command": "node",
-      "args": ["/absolute/path/to/mcp-server-extended-gitlab/dist/mcpServer.js"]
+      "args": ["/absolute/path/to/mcp-server-extended-gitlab/dist/mcpServer.js"],
+      "env": {
+        "TOOLS_INCLUDE": "projects,merge_requests"
+      }
     }
   }
 }
@@ -180,7 +229,7 @@ After publishing the project to npm you can instead use:
   "mcpServers": {
     "gitlab-server": {
       "command": "npx",
-      "args": ["mcp-server-extended-gitlab"]
+      "args": ["mcp-server-extended-gitlab", "--includes=projects,merge_requests"]
     }
   }
 }
@@ -188,7 +237,7 @@ After publishing the project to npm you can instead use:
 
 ### Cursor
 
-1. Run `npm run start:mcp`.
+1. Run `npm run start:mcp` (append `-- --includes=projects,merge_requests` to limit tools).
 2. Create or edit `mcp_servers.json` in your Cursor data directory:
    - **macOS:** `~/Library/Application Support/Cursor/mcp_servers.json`
    - **Windows:** `%APPDATA%/Cursor/mcp_servers.json`
@@ -220,3 +269,4 @@ Issues and PRs are welcome! Please follow the existing coding style and include 
 ## 📜 License
 
 Released under the **MIT License**.
+

--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -1,7 +1,48 @@
+import { readFile } from 'fs/promises';
+
+export function parseArgs(argv: string[]) {
+  const options: {
+    port?: number;
+    includes?: string[];
+    excludes?: string[];
+    configPath?: string;
+  } = {};
+  argv.forEach((arg) => {
+    if (arg.startsWith('--port=')) {
+      const val = Number(arg.slice(7));
+      if (!Number.isNaN(val)) options.port = val;
+    } else if (arg.startsWith('--includes=')) {
+      options.includes = arg
+        .slice(11)
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean);
+    } else if (arg.startsWith('--excludes=')) {
+      options.excludes = arg
+        .slice(11)
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean);
+    } else if (arg.startsWith('--config=')) {
+      options.configPath = arg.slice(9);
+    }
+  });
+  return options;
+}
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('../package.json');
 
-export async function createMcpServer({ port }: { port?: number } = {}) {
+export async function createMcpServer({
+  port,
+  includes,
+  excludes,
+  configPath,
+}: {
+  port?: number;
+  includes?: string[];
+  excludes?: string[];
+  configPath?: string;
+} = {}) {
   let MCPServer: any;
   try {
     ({ MCPServer } = require('mcp-framework'));
@@ -22,11 +63,59 @@ export async function createMcpServer({ port }: { port?: number } = {}) {
     },
   });
 
+  let fileConfig: { includes?: string[]; excludes?: string[] } = {};
+  if (configPath) {
+    try {
+      const data = await readFile(configPath, 'utf8');
+      fileConfig = JSON.parse(data);
+    } catch (err) {
+      throw new Error(`Failed to read config file ${configPath}: ${String(err)}`);
+    }
+  }
+
+  const parseList = (value?: string | string[]): string[] | undefined => {
+    if (!value) return undefined;
+    const array = Array.isArray(value) ? value : value.split(',');
+    return array.map((v) => v.trim()).filter(Boolean);
+  };
+
+  const includesList =
+    includes ?? parseList(fileConfig.includes) ?? parseList(process.env.TOOLS_INCLUDE);
+  const excludesList =
+    excludes ?? parseList(fileConfig.excludes) ?? parseList(process.env.TOOLS_EXCLUDE);
+
+  if (typeof server.start === 'function') {
+    const originalStart = server.start.bind(server);
+    server.start = async () => {
+      await originalStart();
+      const map: Map<string, unknown> =
+        (server as any).toolsMap || (server as any).tools;
+      if (!map) {
+        return;
+      }
+      const entries = Array.from(map.entries()) as [string, unknown][];
+      if (includesList?.length) {
+        const filtered = new Map(
+          entries.filter(([name]) => includesList.includes(name)),
+        );
+        (server as any).toolsMap = filtered;
+        if ((server as any).tools) (server as any).tools = filtered;
+      } else if (excludesList?.length) {
+        const filtered = new Map(
+          entries.filter(([name]) => !excludesList.includes(name)),
+        );
+        (server as any).toolsMap = filtered;
+        if ((server as any).tools) (server as any).tools = filtered;
+      }
+    };
+  }
+
   return server;
 }
 
 if (require.main === module) {
-  createMcpServer().then((server) => {
+  const options = parseArgs(process.argv.slice(2));
+  createMcpServer(options).then((server) => {
     server.start().catch((err: unknown) => {
       console.error('Failed to start MCP server', err);
       process.exit(1);

--- a/tests/mcpServer.cliArgs.test.ts
+++ b/tests/mcpServer.cliArgs.test.ts
@@ -1,0 +1,15 @@
+import { parseArgs } from '../src/mcpServer';
+
+describe('parseArgs', () => {
+  it('parses includes and excludes', () => {
+    const result = parseArgs(['--includes=foo,bar', '--excludes=baz']);
+    expect(result.includes).toEqual(['foo', 'bar']);
+    expect(result.excludes).toEqual(['baz']);
+  });
+
+  it('parses port and config path', () => {
+    const result = parseArgs(['--port=4000', '--config=mcp.json']);
+    expect(result.port).toBe(4000);
+    expect(result.configPath).toBe('mcp.json');
+  });
+});

--- a/tests/mcpServer.toolFilter.test.ts
+++ b/tests/mcpServer.toolFilter.test.ts
@@ -1,0 +1,78 @@
+import { jest } from '@jest/globals';
+
+jest.mock('mcp-framework', () => {
+  class MockMCPServer {
+    toolsMap = new Map();
+    async start() {
+      this.toolsMap = new Map([
+        ['hello', { name: 'hello' }],
+        ['foo', { name: 'foo' }],
+        ['bar', { name: 'bar' }],
+      ]);
+    }
+  }
+  return { MCPServer: MockMCPServer };
+}, { virtual: true });
+
+describe('createMcpServer tool filtering', () => {
+  afterEach(() => {
+    jest.resetModules();
+    delete process.env.TOOLS_INCLUDE;
+    delete process.env.TOOLS_EXCLUDE;
+  });
+
+  it('keeps only included tools', async () => {
+    const { createMcpServer } = await import('../src/mcpServer');
+    const server: any = await createMcpServer({ includes: ['hello', 'bar'] });
+    await server.start();
+    expect([...server.toolsMap.keys()]).toEqual(['hello', 'bar']);
+  });
+
+  it('excludes tools via env variable', async () => {
+    process.env.TOOLS_EXCLUDE = 'foo';
+    const { createMcpServer } = await import('../src/mcpServer');
+    const server: any = await createMcpServer();
+    await server.start();
+    expect([...server.toolsMap.keys()]).toEqual(['hello', 'bar']);
+  });
+
+  it('includes list overrides excludes', async () => {
+    process.env.TOOLS_INCLUDE = 'foo';
+    process.env.TOOLS_EXCLUDE = 'foo';
+    const { createMcpServer } = await import('../src/mcpServer');
+    const server: any = await createMcpServer();
+    await server.start();
+    expect([...server.toolsMap.keys()]).toEqual(['foo']);
+  });
+
+  it('reads includes from config file', async () => {
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const configPath = path.join(__dirname, 'mcp.config.json');
+    await fs.writeFile(configPath, JSON.stringify({ includes: ['foo'] }));
+    const { createMcpServer } = await import('../src/mcpServer');
+    const server: any = await createMcpServer({ configPath });
+    await server.start();
+    await fs.unlink(configPath);
+    expect([...server.toolsMap.keys()]).toEqual(['foo']);
+  });
+
+  it('arguments override config file', async () => {
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const configPath = path.join(__dirname, 'mcp.config.json');
+    await fs.writeFile(configPath, JSON.stringify({ includes: ['foo'] }));
+    const { createMcpServer } = await import('../src/mcpServer');
+    const server: any = await createMcpServer({ includes: ['bar'], configPath });
+    await server.start();
+    await fs.unlink(configPath);
+    expect([...server.toolsMap.keys()]).toEqual(['bar']);
+  });
+
+  it('loads all tools by default', async () => {
+    const { createMcpServer } = await import('../src/mcpServer');
+    const server: any = await createMcpServer();
+    await server.start();
+    expect([...server.toolsMap.keys()]).toEqual(['hello', 'foo', 'bar']);
+  });
+});

--- a/tests/sse.test.ts
+++ b/tests/sse.test.ts
@@ -1,6 +1,8 @@
 import http from 'http';
 import { createApp } from '../src/createApp';
 
+jest.setTimeout(30000);
+
 describe('SSE transport', () => {
   it('exposes SSE endpoint and message delivery', (done) => {
     const app = createApp();


### PR DESCRIPTION
## Summary
- add `parseArgs` to read CLI options in `mcpServer.ts`
- allow specifying tools via `--includes` or `--excludes`
- document CLI/environment usage in README examples
- test CLI argument parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684acba1f234832b81cbb1d626fc209a