### PR TITLE
Add issue discussion routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ The server exposes the following endpoints:
 | PUT | `/projects/:id/issues/:issue_id` |
 | PUT | `/projects/:id/issues/:issue_id/close` |
 | PUT | `/projects/:id/issues/:issue_id/reopen` |
+| GET | `/projects/:id/issues/:issue_id/discussions` |
+| GET | `/projects/:id/issues/:issue_id/discussions/:discussion_id` |
+| POST | `/projects/:id/issues/:issue_id/discussions` |
+| POST | `/projects/:id/issues/:issue_id/discussions/:discussion_id/notes` |
+| PUT | `/projects/:id/issues/:issue_id/discussions/:discussion_id/notes/:note_id` |
+| DELETE | `/projects/:id/issues/:issue_id/discussions/:discussion_id/notes/:note_id` |
 | POST | `/groups` |
 | GET | `/groups/:id` |
 | DELETE | `/groups/:id` |

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -509,6 +509,90 @@ export function createApp() {
     }
   });
 
+  app.get('/projects/:id/issues/:iid/discussions', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(await svc.listIssueDiscussions(req.params.id, req.params.iid));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/projects/:id/issues/:iid/discussions/:discussionId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      res.json(
+        await svc.getIssueDiscussion(
+          req.params.id,
+          req.params.iid,
+          req.params.discussionId,
+        ),
+      );
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/issues/:iid/discussions', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const discussion = await svc.createIssueDiscussion(
+        req.params.id,
+        req.params.iid,
+        req.body,
+      );
+      res.status(201).json(discussion);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/projects/:id/issues/:iid/discussions/:discussionId/notes', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const note = await svc.addNoteToIssueDiscussion(
+        req.params.id,
+        req.params.iid,
+        req.params.discussionId,
+        req.body,
+      );
+      res.status(201).json(note);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.put('/projects/:id/issues/:iid/discussions/:discussionId/notes/:noteId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      const note = await svc.updateIssueDiscussion(
+        req.params.id,
+        req.params.iid,
+        req.params.discussionId,
+        req.params.noteId,
+        req.body,
+      );
+      res.json(note);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.delete('/projects/:id/issues/:iid/discussions/:discussionId/notes/:noteId', async (req, res, next: NextFunction) => {
+    try {
+      const svc = new GitLabService();
+      await svc.deleteIssueDiscussion(
+        req.params.id,
+        req.params.iid,
+        req.params.discussionId,
+        req.params.noteId,
+      );
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // List discussions of a merge request
   app.get('/projects/:id/merge_requests/:iid/discussions', async (req, res, next: NextFunction) => {
     try {

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -329,6 +329,77 @@ export class GitLabService {
     return data;
   }
 
+  async listIssueDiscussions(
+    projectId: string | number,
+    issueIid: string | number,
+  ) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/issues/${issueIid}/discussions`,
+    );
+    return data;
+  }
+
+  async getIssueDiscussion(
+    projectId: string | number,
+    issueIid: string | number,
+    discussionId: string,
+  ) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/issues/${issueIid}/discussions/${discussionId}`,
+    );
+    return data;
+  }
+
+  async createIssueDiscussion(
+    projectId: string | number,
+    issueIid: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/issues/${issueIid}/discussions`,
+      payload,
+    );
+    return data;
+  }
+
+  async addNoteToIssueDiscussion(
+    projectId: string | number,
+    issueIid: string | number,
+    discussionId: string,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/issues/${issueIid}/discussions/${discussionId}/notes`,
+      payload,
+    );
+    return data;
+  }
+
+  async updateIssueDiscussion(
+    projectId: string | number,
+    issueIid: string | number,
+    discussionId: string,
+    noteId: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/issues/${issueIid}/discussions/${discussionId}/notes/${noteId}`,
+      payload,
+    );
+    return data;
+  }
+
+  async deleteIssueDiscussion(
+    projectId: string | number,
+    issueIid: string | number,
+    discussionId: string,
+    noteId: string | number,
+  ) {
+    await this.client.delete(
+      `/projects/${projectId}/issues/${issueIid}/discussions/${discussionId}/notes/${noteId}`,
+    );
+  }
+
   async getFile(projectId: string | number, filePath: string, ref: string) {
     const encodedPath = encodeURIComponent(filePath);
     const { data } = await this.client.get(

--- a/tests/gitlab.issue.discussions.test.ts
+++ b/tests/gitlab.issue.discussions.test.ts
@@ -1,0 +1,95 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab issue discussions endpoints', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('lists issue discussions', async () => {
+    const mockData = [{ id: 'abc', notes: [] }];
+    nock(base)
+      .get('/api/v4/projects/123/issues/4/discussions')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/projects/123/issues/4/discussions');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('gets a single issue discussion', async () => {
+    const mockData = { id: 'abc', notes: [] };
+    nock(base)
+      .get('/api/v4/projects/123/issues/4/discussions/abc')
+      .reply(200, mockData);
+
+    const res = await request(app).get(
+      '/projects/123/issues/4/discussions/abc',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('creates an issue discussion', async () => {
+    const payload = { body: 'hi' };
+    const mockData = { id: 'abc', notes: [] };
+    nock(base)
+      .post('/api/v4/projects/123/issues/4/discussions', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/issues/4/discussions')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('adds a note to an issue discussion', async () => {
+    const payload = { body: 'note' };
+    const mockData = { id: 'note1', body: 'note' };
+    nock(base)
+      .post('/api/v4/projects/123/issues/4/discussions/abc/notes', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/issues/4/discussions/abc/notes')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('updates a note in an issue discussion', async () => {
+    const payload = { body: 'edit' };
+    const mockData = { id: 'note1', body: 'edit' };
+    nock(base)
+      .put('/api/v4/projects/123/issues/4/discussions/abc/notes/1', payload)
+      .reply(200, mockData);
+
+    const res = await request(app)
+      .put('/projects/123/issues/4/discussions/abc/notes/1')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a note from an issue discussion', async () => {
+    nock(base)
+      .delete('/api/v4/projects/123/issues/4/discussions/abc/notes/1')
+      .reply(204);
+
+    const res = await request(app).delete(
+      '/projects/123/issues/4/discussions/abc/notes/1',
+    );
+    expect(res.status).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary
- support listing, retrieving and managing issue discussions
- expose REST paths for issue discussions and notes
- document new endpoints in README
- add tests for issue discussion routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad7467084832bb8942f25e7990f22