### PR TITLE
Add commit discussion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ The server exposes the following endpoints:
 | GET | `/projects/:id/branches/:branch` |
 | DELETE | `/projects/:id/branches/:branch` |
 | GET | `/projects/:id/commits` |
+| GET | `/projects/:id/repository/commits/:commit_id/discussions` |
+| GET | `/projects/:id/repository/commits/:commit_id/discussions/:discussion_id` |
+| POST | `/projects/:id/repository/commits/:commit_id/discussions` |
+| POST | `/projects/:id/repository/commits/:commit_id/discussions/:discussion_id/notes` |
+| PUT | `/projects/:id/repository/commits/:commit_id/discussions/:discussion_id/notes/:note_id` |
+| DELETE | `/projects/:id/repository/commits/:commit_id/discussions/:discussion_id/notes/:note_id` |
 | GET | `/projects/:id/pipelines` |
 | GET | `/projects/:id/pipelines/:pipeline_id` |
 | POST | `/projects/:id/pipelines` |

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -359,6 +359,110 @@ export function createApp() {
     }
   });
 
+  app.get(
+    '/projects/:id/repository/commits/:commitId/discussions',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        res.json(
+          await svc.listCommitDiscussions(req.params.id, req.params.commitId),
+        );
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.get(
+    '/projects/:id/repository/commits/:commitId/discussions/:discussionId',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        res.json(
+          await svc.getCommitDiscussion(
+            req.params.id,
+            req.params.commitId,
+            req.params.discussionId,
+          ),
+        );
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.post(
+    '/projects/:id/repository/commits/:commitId/discussions',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        const discussion = await svc.createCommitDiscussion(
+          req.params.id,
+          req.params.commitId,
+          req.body,
+        );
+        res.status(201).json(discussion);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.post(
+    '/projects/:id/repository/commits/:commitId/discussions/:discussionId/notes',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        const note = await svc.addNoteToCommitDiscussion(
+          req.params.id,
+          req.params.commitId,
+          req.params.discussionId,
+          req.body,
+        );
+        res.status(201).json(note);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.put(
+    '/projects/:id/repository/commits/:commitId/discussions/:discussionId/notes/:noteId',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        const note = await svc.updateCommitDiscussion(
+          req.params.id,
+          req.params.commitId,
+          req.params.discussionId,
+          req.params.noteId,
+          req.body,
+        );
+        res.json(note);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.delete(
+    '/projects/:id/repository/commits/:commitId/discussions/:discussionId/notes/:noteId',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        await svc.deleteCommitDiscussion(
+          req.params.id,
+          req.params.commitId,
+          req.params.discussionId,
+          req.params.noteId,
+        );
+        res.status(204).end();
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
   // List pipelines of a project
   app.get('/projects/:id/pipelines', async (req, res, next: NextFunction) => {
     try {

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -215,6 +215,74 @@ export class GitLabService {
     return data;
   }
 
+  async listCommitDiscussions(projectId: string | number, commitId: string) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/repository/commits/${commitId}/discussions`,
+    );
+    return data;
+  }
+
+  async getCommitDiscussion(
+    projectId: string | number,
+    commitId: string,
+    discussionId: string,
+  ) {
+    const { data } = await this.client.get(
+      `/projects/${projectId}/repository/commits/${commitId}/discussions/${discussionId}`,
+    );
+    return data;
+  }
+
+  async createCommitDiscussion(
+    projectId: string | number,
+    commitId: string,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/repository/commits/${commitId}/discussions`,
+      payload,
+    );
+    return data;
+  }
+
+  async addNoteToCommitDiscussion(
+    projectId: string | number,
+    commitId: string,
+    discussionId: string,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/projects/${projectId}/repository/commits/${commitId}/discussions/${discussionId}/notes`,
+      payload,
+    );
+    return data;
+  }
+
+  async updateCommitDiscussion(
+    projectId: string | number,
+    commitId: string,
+    discussionId: string,
+    noteId: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.put(
+      `/projects/${projectId}/repository/commits/${commitId}/discussions/${discussionId}/notes/${noteId}`,
+      payload,
+    );
+    return data;
+  }
+
+  async deleteCommitDiscussion(
+    projectId: string | number,
+    commitId: string,
+    discussionId: string,
+    noteId: string | number,
+  ) {
+    await this.client.delete(
+      `/projects/${projectId}/repository/commits/${commitId}/discussions/${discussionId}/notes/${noteId}`,
+    );
+  }
+
   async listPipelines(projectId: string | number) {
     const { data } = await this.client.get(`/projects/${projectId}/pipelines`);
     return data;

--- a/tests/gitlab.commit.discussions.test.ts
+++ b/tests/gitlab.commit.discussions.test.ts
@@ -1,0 +1,105 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab commit discussions endpoints', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('lists commit discussions', async () => {
+    const mockData = [{ id: 'abc', notes: [] }];
+    nock(base)
+      .get('/api/v4/projects/123/repository/commits/abc123/discussions')
+      .reply(200, mockData);
+
+    const res = await request(app).get(
+      '/projects/123/repository/commits/abc123/discussions',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('gets a single commit discussion', async () => {
+    const mockData = { id: 'abc', notes: [] };
+    nock(base)
+      .get('/api/v4/projects/123/repository/commits/abc123/discussions/abc')
+      .reply(200, mockData);
+
+    const res = await request(app).get(
+      '/projects/123/repository/commits/abc123/discussions/abc',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('creates a commit discussion', async () => {
+    const payload = { body: 'hi' };
+    const mockData = { id: 'abc', notes: [] };
+    nock(base)
+      .post('/api/v4/projects/123/repository/commits/abc123/discussions', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/repository/commits/abc123/discussions')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('adds a note to a commit discussion', async () => {
+    const payload = { body: 'note' };
+    const mockData = { id: 'note1', body: 'note' };
+    nock(base)
+      .post(
+        '/api/v4/projects/123/repository/commits/abc123/discussions/abc/notes',
+        payload,
+      )
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/projects/123/repository/commits/abc123/discussions/abc/notes')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('updates a note in a commit discussion', async () => {
+    const payload = { body: 'edit' };
+    const mockData = { id: 'note1', body: 'edit' };
+    nock(base)
+      .put(
+        '/api/v4/projects/123/repository/commits/abc123/discussions/abc/notes/1',
+        payload,
+      )
+      .reply(200, mockData);
+
+    const res = await request(app)
+      .put('/projects/123/repository/commits/abc123/discussions/abc/notes/1')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a note from a commit discussion', async () => {
+    nock(base)
+      .delete(
+        '/api/v4/projects/123/repository/commits/abc123/discussions/abc/notes/1',
+      )
+      .reply(204);
+
+    const res = await request(app).delete(
+      '/projects/123/repository/commits/abc123/discussions/abc/notes/1',
+    );
+    expect(res.status).toBe(204);
+  });
+});

--- a/tests/sse.test.ts
+++ b/tests/sse.test.ts
@@ -1,9 +1,20 @@
 import http from 'http';
 import { createApp } from '../src/createApp';
+import nock from 'nock';
 
 jest.setTimeout(30000);
 
 describe('SSE transport', () => {
+  beforeAll(() => {
+    // Ensure local connections bypass proxy settings used in CI
+    process.env.http_proxy = '';
+    process.env.HTTP_PROXY = '';
+    nock.enableNetConnect();
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+  });
   it('exposes SSE endpoint and message delivery', (done) => {
     const app = createApp();
     const server = app.listen(() => {


### PR DESCRIPTION
## Summary
- extend `GitLabService` with commit discussion APIs
- expose commit discussion routes in the Express app
- document commit discussion endpoints in README
- test commit discussion functionality via mocked GitLab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684add3d9bb4832bbf855ad687bd81c0