### PR TITLE
Add epic discussion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ The server exposes the following endpoints:
 | GET | `/groups/:id` |
 | DELETE | `/groups/:id` |
 | GET | `/groups/:id/members` |
+| GET | `/groups/:id/epics` |
+| GET | `/groups/:id/epics/:epic_id/discussions` |
+| GET | `/groups/:id/epics/:epic_id/discussions/:discussion_id` |
+| POST | `/groups/:id/epics/:epic_id/discussions` |
+| POST | `/groups/:id/epics/:epic_id/discussions/:discussion_id/notes` |
+| PUT | `/groups/:id/epics/:epic_id/discussions/:discussion_id/notes/:note_id` |
+| DELETE | `/groups/:id/epics/:epic_id/discussions/:discussion_id/notes/:note_id` |
+
+GitLab's documentation notes that the epic discussions API is deprecated and may be removed in a future release.
 
 ---
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -71,6 +71,110 @@ export function createApp() {
     }
   });
 
+  app.get(
+    '/groups/:id/epics/:epic_id/discussions',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        res.json(
+          await svc.listEpicDiscussions(req.params.id, req.params.epic_id),
+        );
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.get(
+    '/groups/:id/epics/:epic_id/discussions/:discussionId',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        res.json(
+          await svc.getEpicDiscussion(
+            req.params.id,
+            req.params.epic_id,
+            req.params.discussionId,
+          ),
+        );
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.post(
+    '/groups/:id/epics/:epic_id/discussions',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        const discussion = await svc.createEpicDiscussion(
+          req.params.id,
+          req.params.epic_id,
+          req.body,
+        );
+        res.status(201).json(discussion);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.post(
+    '/groups/:id/epics/:epic_id/discussions/:discussionId/notes',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        const note = await svc.addNoteToEpicDiscussion(
+          req.params.id,
+          req.params.epic_id,
+          req.params.discussionId,
+          req.body,
+        );
+        res.status(201).json(note);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.put(
+    '/groups/:id/epics/:epic_id/discussions/:discussionId/notes/:noteId',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        const note = await svc.updateEpicDiscussion(
+          req.params.id,
+          req.params.epic_id,
+          req.params.discussionId,
+          req.params.noteId,
+          req.body,
+        );
+        res.json(note);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.delete(
+    '/groups/:id/epics/:epic_id/discussions/:discussionId/notes/:noteId',
+    async (req, res, next: NextFunction) => {
+      try {
+        const svc = new GitLabService();
+        await svc.deleteEpicDiscussion(
+          req.params.id,
+          req.params.epic_id,
+          req.params.discussionId,
+          req.params.noteId,
+        );
+        res.status(204).end();
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
   app.get('/projects/:id/access_tokens', async (req, res, next: NextFunction) => {
     try {
       const svc = new GitLabService();

--- a/src/services/GitLabService.ts
+++ b/src/services/GitLabService.ts
@@ -746,6 +746,74 @@ export class GitLabService {
     const { data } = await this.client.get(`/groups/${groupId}/epics`);
     return data;
   }
+
+  async listEpicDiscussions(groupId: string | number, epicIid: string | number) {
+    const { data } = await this.client.get(
+      `/groups/${groupId}/epics/${epicIid}/discussions`,
+    );
+    return data;
+  }
+
+  async getEpicDiscussion(
+    groupId: string | number,
+    epicIid: string | number,
+    discussionId: string,
+  ) {
+    const { data } = await this.client.get(
+      `/groups/${groupId}/epics/${epicIid}/discussions/${discussionId}`,
+    );
+    return data;
+  }
+
+  async createEpicDiscussion(
+    groupId: string | number,
+    epicIid: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/groups/${groupId}/epics/${epicIid}/discussions`,
+      payload,
+    );
+    return data;
+  }
+
+  async addNoteToEpicDiscussion(
+    groupId: string | number,
+    epicIid: string | number,
+    discussionId: string,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.post(
+      `/groups/${groupId}/epics/${epicIid}/discussions/${discussionId}/notes`,
+      payload,
+    );
+    return data;
+  }
+
+  async updateEpicDiscussion(
+    groupId: string | number,
+    epicIid: string | number,
+    discussionId: string,
+    noteId: string | number,
+    payload: Record<string, unknown>,
+  ) {
+    const { data } = await this.client.put(
+      `/groups/${groupId}/epics/${epicIid}/discussions/${discussionId}/notes/${noteId}`,
+      payload,
+    );
+    return data;
+  }
+
+  async deleteEpicDiscussion(
+    groupId: string | number,
+    epicIid: string | number,
+    discussionId: string,
+    noteId: string | number,
+  ) {
+    await this.client.delete(
+      `/groups/${groupId}/epics/${epicIid}/discussions/${discussionId}/notes/${noteId}`,
+    );
+  }
   async listDeployKeys(projectId: string | number) {
     const { data } = await this.client.get(`/projects/${projectId}/deploy_keys`);
     return data;

--- a/tests/gitlab.epic.discussions.test.ts
+++ b/tests/gitlab.epic.discussions.test.ts
@@ -1,0 +1,93 @@
+import request from 'supertest';
+import { createApp } from '../src/createApp';
+import nock from 'nock';
+
+describe('GitLab group epic discussions endpoints', () => {
+  const app = createApp();
+  const base = 'https://gitlab.example.com';
+
+  beforeAll(() => {
+    process.env.GITLAB_BASE_URL = base + '/api/v4';
+    process.env.GITLAB_TOKEN = 'testtoken';
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('lists epic discussions', async () => {
+    const mockData = [{ id: 'abc', notes: [] }];
+    nock(base)
+      .get('/api/v4/groups/5/epics/10/discussions')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/groups/5/epics/10/discussions');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('gets a single epic discussion', async () => {
+    const mockData = { id: 'abc', notes: [] };
+    nock(base)
+      .get('/api/v4/groups/5/epics/10/discussions/abc')
+      .reply(200, mockData);
+
+    const res = await request(app).get('/groups/5/epics/10/discussions/abc');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('creates an epic discussion', async () => {
+    const payload = { body: 'hi' };
+    const mockData = { id: 'abc', notes: [] };
+    nock(base)
+      .post('/api/v4/groups/5/epics/10/discussions', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/groups/5/epics/10/discussions')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('adds a note to an epic discussion', async () => {
+    const payload = { body: 'note' };
+    const mockData = { id: 'note1', body: 'note' };
+    nock(base)
+      .post('/api/v4/groups/5/epics/10/discussions/abc/notes', payload)
+      .reply(201, mockData);
+
+    const res = await request(app)
+      .post('/groups/5/epics/10/discussions/abc/notes')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('updates a note in an epic discussion', async () => {
+    const payload = { body: 'edit' };
+    const mockData = { id: 'note1', body: 'edit' };
+    nock(base)
+      .put('/api/v4/groups/5/epics/10/discussions/abc/notes/1', payload)
+      .reply(200, mockData);
+
+    const res = await request(app)
+      .put('/groups/5/epics/10/discussions/abc/notes/1')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+
+  it('deletes a note from an epic discussion', async () => {
+    nock(base)
+      .delete('/api/v4/groups/5/epics/10/discussions/abc/notes/1')
+      .reply(204);
+
+    const res = await request(app).delete(
+      '/groups/5/epics/10/discussions/abc/notes/1',
+    );
+    expect(res.status).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary
- implement GitLabService methods for group epic discussions
- wire up routes for `/groups/:id/epics/:epic_id/discussions`
- test epic discussion endpoints
- document new endpoints and note GitLab deprecation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae4ebe848832b891e727c0b56129e