### PR TITLE
Fix build step by adding CLI entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   "bugs": {
     "url": "https://github.com/Xopoko/mcp-server-extended-gitlab/issues"
   },
-  "homepage": "https://github.com/Xopoko/mcp-server-extended-gitlab#readme"
+  "homepage": "https://github.com/Xopoko/mcp-server-extended-gitlab#readme",
+  "bin": {
+    "mcp-server-extended-gitlab": "dist/index.js"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,17 @@ import { createMcpServer, parseArgs } from './mcpServer';
 
 export { createMcpServer, parseArgs } from './mcpServer';
 
+export async function runCli(argv: string[] = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  try {
+    const server = await createMcpServer(options);
+    await server.start();
+  } catch (err) {
+    console.error('Failed to create or start MCP server', err);
+    process.exit(1);
+  }
+}
+
 if (require.main === module) {
-  const options = parseArgs(process.argv.slice(2));
-  createMcpServer(options).then((server) => {
-    server.start().catch((err: unknown) => {
-      console.error('Failed to start MCP server', err);
-      process.exit(1);
-    });
-  });
+  void runCli();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { createMcpServer, parseArgs } from './mcpServer';
+
+export { createMcpServer, parseArgs } from './mcpServer';
+
+if (require.main === module) {
+  const options = parseArgs(process.argv.slice(2));
+  createMcpServer(options).then((server) => {
+    server.start().catch((err: unknown) => {
+      console.error('Failed to start MCP server', err);
+      process.exit(1);
+    });
+  });
+}

--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -115,10 +115,15 @@ export async function createMcpServer({
 
 if (require.main === module) {
   const options = parseArgs(process.argv.slice(2));
-  createMcpServer(options).then((server) => {
-    server.start().catch((err: unknown) => {
-      console.error('Failed to start MCP server', err);
+  createMcpServer(options)
+    .then((server) => {
+      server.start().catch((err: unknown) => {
+        console.error('Failed to start MCP server', err);
+        process.exit(1);
+      });
+    })
+    .catch((err: unknown) => {
+      console.error('Failed to create MCP server', err);
       process.exit(1);
     });
-  });
 }

--- a/tests/index.file.test.ts
+++ b/tests/index.file.test.ts
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('source entry file', () => {
+  it('should include src/index.ts for CLI entrypoint', () => {
+    const filePath = path.join(__dirname, '../src/index.ts');
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+});

--- a/tests/package.bin.test.ts
+++ b/tests/package.bin.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('package.json bin', () => {
+  it('should expose CLI command', () => {
+    const pkgPath = path.join(__dirname, '../package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    expect(pkg.bin && pkg.bin['mcp-server-extended-gitlab']).toBe('dist/index.js');
+  });
+});

--- a/tests/runCli.error.test.ts
+++ b/tests/runCli.error.test.ts
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+
+jest.mock('../src/mcpServer', () => ({
+  createMcpServer: () => Promise.reject(new Error('fail')),
+  parseArgs: () => ({}),
+}));
+
+describe('CLI error handling', () => {
+  it('exits with code 1 when createMcpServer rejects', async () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('../src/index');
+    await expect(runCli()).rejects.toThrow('exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    (console.error as jest.Mock).mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- create `src/index.ts` as CLI entrypoint wrapping `createMcpServer`
- expose command via `bin` field in package.json
- add tests ensuring the CLI entry and bin configuration exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ae86cc7ac832ba35a44f520d38a10