### PR TITLE
Fix npm package to include dist build

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   "homepage": "https://github.com/Xopoko/mcp-server-extended-gitlab#readme",
   "bin": {
     "mcp-server-extended-gitlab": "dist/index.js"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/tests/package.files.test.ts
+++ b/tests/package.files.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('package.json files', () => {
+  it('should include dist directory', () => {
+    const pkgPath = path.join(__dirname, '../package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    expect(pkg.files).toContain('dist');
+  });
+});


### PR DESCRIPTION
## Summary
- add a test verifying the npm package publishes the `dist` directory
- ensure package.json includes the `dist` folder via the `files` field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684af2fd8b84832b877b22ff456ef049