### PR TITLE
Fix tools loading path

### DIFF
--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -54,7 +54,7 @@ export async function createMcpServer({
   const server = new MCPServer({
     name: pkg.name,
     version: pkg.version,
-    basePath: __dirname,
+    basePath: __filename,
     transport: {
       type: 'sse',
       options: {

--- a/src/stdioServer.ts
+++ b/src/stdioServer.ts
@@ -2,7 +2,7 @@ const importer = new Function('p', 'return import(p)');
 (async () => {
   const { MCPServer } = await importer('mcp-framework');
   const server = new MCPServer({
-    basePath: __dirname,
+    basePath: __filename,
     transport: { type: 'stdio' },
   });
 

--- a/tests/mcpServer.basePath.test.ts
+++ b/tests/mcpServer.basePath.test.ts
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+import path from 'path';
+
+jest.mock('mcp-framework', () => {
+  return {
+    MCPServer: class {
+      basePath: string;
+      constructor(config: any) {
+        this.basePath = config.basePath;
+      }
+    }
+  };
+}, { virtual: true });
+
+describe('createMcpServer basePath', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('uses file path as basePath', async () => {
+    const { createMcpServer } = await import('../src/mcpServer');
+    const server: any = await createMcpServer();
+    const expected = path.join(__dirname, '../src/mcpServer.ts');
+    expect(server.basePath).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure MCPServer loads built tools by providing the file path
- adjust stdio server similarly
- add regression test for basePath

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684afa94a7c0832ba51a7db068c2dc83